### PR TITLE
 use rounded-blume token in PageFeedback and Pagination

### DIFF
--- a/.changeset/rounded-blume-feedback-pagination.md
+++ b/.changeset/rounded-blume-feedback-pagination.md
@@ -1,0 +1,7 @@
+---
+"blume": patch
+---
+
+Use the `rounded-blume` radius token instead of a hardcoded `rounded-full` on the `PageFeedback` and `Pagination` buttons so they respect the configured `theme.radius`.
+
+Fixes #36.

--- a/packages/blume/src/components/layout/PageFeedback.astro
+++ b/packages/blume/src/components/layout/PageFeedback.astro
@@ -15,7 +15,7 @@ const { strings } = Astro.props;
 const f = { ...EN_UI.feedback, ...strings };
 
 const buttonClass =
-  "inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-foreground text-sm transition-colors hover:border-foreground";
+  "inline-flex items-center gap-2 rounded-blume border border-border px-4 py-2 text-foreground text-sm transition-colors hover:border-foreground";
 ---
 
 <section

--- a/packages/blume/src/components/layout/Pagination.astro
+++ b/packages/blume/src/components/layout/Pagination.astro
@@ -30,7 +30,7 @@ const s = { ...EN_UI.page, ...strings };
     >
       {prev ? (
         <a
-          class="flex max-w-[48%] flex-1 items-center gap-2 rounded-full border border-border px-4 py-3 text-foreground transition-colors hover:border-foreground max-md:max-w-full"
+          class="flex max-w-[48%] flex-1 items-center gap-2 rounded-blume border border-border px-4 py-3 text-foreground transition-colors hover:border-foreground max-md:max-w-full"
           href={withBase(prev.route)}
         >
           <Icon class="rtl:-scale-x-100" name="arrow-left" size={16} />
@@ -46,7 +46,7 @@ const s = { ...EN_UI.page, ...strings };
       )}
       {next && (
         <a
-          class="ms-auto flex max-w-[48%] flex-1 items-center justify-end gap-2 rounded-full border border-border px-4 py-3 text-end text-foreground transition-colors hover:border-foreground max-md:max-w-full"
+          class="ms-auto flex max-w-[48%] flex-1 items-center justify-end gap-2 rounded-blume border border-border px-4 py-3 text-end text-foreground transition-colors hover:border-foreground max-md:max-w-full"
           href={withBase(next.route)}
         >
           <span>


### PR DESCRIPTION
## Description

Replace hardcoded rounded-full with the rounded-blume design token in `PageFeedback` and `Pagination` components, so that they respect the configurable --blume-radius theme variable.

## Related Issues

Closes #36 

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary

## Screenshots (if applicable)

The fix ensures custom radius values are respected

## Additional Notes

There are additional components still using hardcoded rounded-full that should also use rounded-blume (e.g. Search, LanguageSwitcher, Banner). Happy to commit those fixes to address those two.
