### PR TITLE
fix: truncate pagination labels and allow inline code to break in tables

### DIFF
--- a/.changeset/pagination-truncate-inline-code-overflow.md
+++ b/.changeset/pagination-truncate-inline-code-overflow.md
@@ -1,0 +1,7 @@
+---
+"blume": patch
+---
+
+Truncate long page titles in the previous/next pagination links so they no longer overflow their pill container, and allow inline code inside table cells to wrap instead of forcing the whole table to overflow horizontally.
+
+Fixes #38 and #41.

--- a/packages/blume/src/components/layout/Pagination.astro
+++ b/packages/blume/src/components/layout/Pagination.astro
@@ -34,11 +34,11 @@ const s = { ...EN_UI.page, ...strings };
           href={withBase(prev.route)}
         >
           <Icon class="rtl:-scale-x-100" name="arrow-left" size={16} />
-          <span>
+          <span class="min-w-0">
             <span class="block text-muted-foreground text-xs max-md:hidden">
               {s.previous}
             </span>
-            <span class="block font-medium">{prev.label}</span>
+            <span class="block truncate font-medium">{prev.label}</span>
           </span>
         </a>
       ) : (
@@ -49,11 +49,11 @@ const s = { ...EN_UI.page, ...strings };
           class="ms-auto flex max-w-[48%] flex-1 items-center justify-end gap-2 rounded-full border border-border px-4 py-3 text-end text-foreground transition-colors hover:border-foreground max-md:max-w-full"
           href={withBase(next.route)}
         >
-          <span>
+          <span class="min-w-0">
             <span class="block text-muted-foreground text-xs max-md:hidden">
               {s.next}
             </span>
-            <span class="block font-medium">{next.label}</span>
+            <span class="block truncate font-medium">{next.label}</span>
           </span>
           <Icon class="rtl:-scale-x-100" name="arrow-right" size={16} />
         </a>

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -457,7 +457,8 @@ blume-diff {
    never matches (a cell is not its own descendant). */
 .prose :where(td, th) > code,
 .prose :where(td, th) :not(pre) > code {
-  white-space: nowrap;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 blume-tabs pre,


### PR DESCRIPTION
## Summary

Fixes #38 and #41.

### Pagination label truncation (#38)
Long page titles in the previous/next navigation links caused the pagination component to overflow its container. This adds:
- `truncate` class to the page label `<span>` so text is clipped with an ellipsis
- `min-w-0` on the label container so flex items can shrink below their intrinsic content width

### Inline code overflow in tables (#41)
Inline code inside table cells had `white-space: nowrap`, which prevented line breaking and caused the entire table to overflow horizontally when code content was long. Changed to:
- `overflow-wrap: break-word` — allows long words/identifiers to break at arbitrary points
- `white-space: normal` — permits wrapping within the code element

This keeps code readable in tables without sacrificing layout stability.

## Testing
- Verified both pagination truncation and table code wrapping work with long content