### PR TITLE
Wrap markdown tables in a horizontal-scroll container

### DIFF
--- a/.changeset/wide-tables-scroll.md
+++ b/.changeset/wide-tables-scroll.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Wrap markdown tables in a horizontal-scroll container so wide tables no longer overflow the prose column.

--- a/.changeset/wide-tables-scroll.md
+++ b/.changeset/wide-tables-scroll.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Wrap markdown tables in a horizontal-scroll container so wide tables no longer overflow the prose column.
+Wrap markdown tables in a horizontal-scroll container so wide tables no longer overflow the prose column. The wrapper is framed with a rounded border and cell padding, and header labels stay on one line, so a clipped wide table reads as scrollable rather than cut off.

--- a/packages/blume/src/markdown/index.ts
+++ b/packages/blume/src/markdown/index.ts
@@ -17,6 +17,7 @@ import { languageIconTransformer } from "./language-icon.ts";
 import { mathPlugin } from "./math.ts";
 import { mermaidPlugin } from "./mermaid.ts";
 import { packageInstallPlugin } from "./package-install.ts";
+import { tableWrapPlugin } from "./table-wrap.ts";
 import { DEFAULT_CODE_THEMES } from "./themes.ts";
 import type { CodeThemes } from "./themes.ts";
 
@@ -58,6 +59,7 @@ type HastPlugin = NonNullable<
 const blumeHastPlugins = (options: BlumeMarkdownOptions): HastPlugin[] => {
   const plugins: HastPlugin[] = [
     inlineCodeHighlightPlugin(options.codeThemes) as unknown as HastPlugin,
+    tableWrapPlugin() as unknown as HastPlugin,
   ];
   if (options.headingAnchors !== false) {
     plugins.push(headingAnchorPlugin() as unknown as HastPlugin);

--- a/packages/blume/src/markdown/table-wrap.ts
+++ b/packages/blume/src/markdown/table-wrap.ts
@@ -1,0 +1,34 @@
+/** Wraps each `<table>` in a scroll container. Satteri does not re-descend into a visitor's returned replacement, so the wrapped table is not re-visited. */
+
+/** A minimal hast node (avoids a hast type dependency). */
+interface HastNode {
+  children?: HastNode[];
+  properties?: Record<string, unknown>;
+  tagName?: string;
+  type: string;
+  value?: string;
+}
+
+/** A Satteri hast plugin, typed structurally to avoid a Satteri dep. */
+export interface TableWrapPlugin {
+  name: string;
+  element: {
+    filter: string[];
+    visit: (node: HastNode) => HastNode;
+  };
+}
+
+export const tableWrapPlugin = (): TableWrapPlugin => ({
+  element: {
+    filter: ["table"],
+    visit(node) {
+      return {
+        children: [node],
+        properties: { className: ["blume-table-scroll"] },
+        tagName: "div",
+        type: "element",
+      };
+    },
+  },
+  name: "blume:table-wrap",
+});

--- a/packages/blume/src/markdown/table-wrap.ts
+++ b/packages/blume/src/markdown/table-wrap.ts
@@ -1,4 +1,13 @@
-/** Wraps each `<table>` in a scroll container. Satteri does not re-descend into a visitor's returned replacement, so the wrapped table is not re-visited. */
+/**
+ * Wraps each `<table>` in a scroll container. Satteri does not re-descend into a
+ * visitor's returned replacement, so the wrapped table is not re-visited.
+ *
+ * The wrapper carries `tabindex="0"` so a horizontally scrolling table is
+ * reachable and scrollable by keyboard, not just pointer (WCAG 2.1.1; axe's
+ * `scrollable-region-focusable`). It's added unconditionally — whether a given
+ * table overflows isn't known at build time — which costs a tab stop on tables
+ * that happen to fit; no ARIA label is set to avoid an untranslated string.
+ */
 
 /** A minimal hast node (avoids a hast type dependency). */
 interface HastNode {
@@ -24,7 +33,7 @@ export const tableWrapPlugin = (): TableWrapPlugin => ({
     visit(node) {
       return {
         children: [node],
-        properties: { className: ["blume-table-scroll"] },
+        properties: { className: ["blume-table-scroll"], tabIndex: 0 },
         tagName: "div",
         type: "element",
       };

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -453,10 +453,32 @@ blume-diff {
   font-size: 0.8125rem;
 }
 
-/* Scroll wide tables in place; the wrapper is added by the blume:table-wrap hast plugin. */
+/* Scroll wide tables in place; the wrapper is added by the blume:table-wrap hast
+   plugin. The border+radius frames the scroll viewport so a clipped wide table
+   reads as scrollable rather than cut off, and carries the table's vertical
+   rhythm (the inner table's own margin is zeroed so it fills the frame). */
 .blume-table-scroll {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  margin: 1.5rem 0;
+  border: 1px solid var(--blume-border);
+  border-radius: var(--blume-radius);
+}
+.blume-table-scroll > table {
+  margin: 0;
+}
+/* Restore inner padding on every cell. Typography zeroes the first/last cell's
+   inline padding so a borderless table aligns to the prose margin; inside the
+   framed wrapper that leaves edge text touching the border. The :is() selector
+   outweighs Typography's :where()-scoped rules so the outer columns get it too. */
+.blume-table-scroll :is(th, td) {
+  padding: 0.5rem 0.75rem;
+}
+/* Keep column labels on one line so a two-word header does not wrap into a
+   ragged stack; the table just scrolls a little wider instead. Body cells keep
+   wrapping so a wide table stays a scroll away, not an endless horizontal run. */
+.blume-table-scroll th {
+  white-space: nowrap;
 }
 
 /* GFM renders cells as <td><code> directly, which the descendant form alone

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -453,6 +453,12 @@ blume-diff {
   font-size: 0.8125rem;
 }
 
+/* Scroll wide tables in place; the wrapper is added by the blume:table-wrap hast plugin. */
+.blume-table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* GFM renders cells as <td><code> directly, which the descendant form alone
    never matches (a cell is not its own descendant). */
 .prose :where(td, th) > code,

--- a/packages/blume/test/table-wrap.test.ts
+++ b/packages/blume/test/table-wrap.test.ts
@@ -21,4 +21,11 @@ describe("tableWrapPlugin", () => {
     expect(result?.properties?.className).toEqual(["blume-table-scroll"]);
     expect(result?.children).toEqual([table]);
   });
+
+  it("makes the wrapper keyboard-focusable so it can be scrolled", () => {
+    const table = { tagName: "table", type: "element" };
+    const result = tableWrapPlugin().element.visit(table as never);
+
+    expect(result?.properties?.tabIndex).toBe(0);
+  });
 });

--- a/packages/blume/test/table-wrap.test.ts
+++ b/packages/blume/test/table-wrap.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+
+import { tableWrapPlugin } from "../src/markdown/table-wrap.ts";
+
+describe("tableWrapPlugin", () => {
+  it("targets only table elements", () => {
+    expect(tableWrapPlugin().element.filter).toEqual(["table"]);
+  });
+
+  it("wraps a <table> in a scroll-container div and reuses the original node", () => {
+    const table = {
+      children: [{ tagName: "tbody", type: "element" }],
+      properties: { className: ["x"] },
+      tagName: "table",
+      type: "element",
+    };
+    const result = tableWrapPlugin().element.visit(table as never);
+
+    expect(result?.tagName).toBe("div");
+    expect(result?.type).toBe("element");
+    expect(result?.properties?.className).toEqual(["blume-table-scroll"]);
+    expect(result?.children).toEqual([table]);
+  });
+});


### PR DESCRIPTION
## Summary
- Wide markdown tables overflow the x-axis because the built-in table render has no scroll wrapper.
- Adds a `blume:table-wrap` hast plugin that wraps every `<table>` in `<div class="blume-table-scroll">…</div>`, registered in the shared hast pipeline so it covers both `.md` and `.mdx`.
- Adds `.blume-table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch }` to the theme.
- The visitor returns a replacement node; Satteri does not re-descend into it, so the wrapped table is not re-visited (no double-wrap).
- Adds a changeset (`blume` patch).

## Test plan
- [x] `bun test packages/blume/test/table-wrap.test.ts` — new unit test asserts the visitor wraps a `table` in the scroll div and reuses the original node.
- [x] `bun run typecheck` (blume package) — clean.
- [x] `oxfmt --check` / `oxlint --quiet` on changed files — clean.
- [ ] Build a docs page with a 7+ column table; confirm it scrolls in place instead of overflowing.