### PR TITLE
Keep root tabs active on child routes

### DIFF
--- a/.changeset/root-tab-child-routes.md
+++ b/.changeset/root-tab-child-routes.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Keep root navigation tabs active on descendant routes unless a more specific tab matches.

--- a/packages/blume/src/components/layout/Header.astro
+++ b/packages/blume/src/components/layout/Header.astro
@@ -10,7 +10,7 @@ import { GITHUB_MARK } from "../github-mark.ts";
 import Icon from "../Icon.astro";
 import LanguageSwitcher from "./LanguageSwitcher.astro";
 import Logo from "./Logo.astro";
-import { isUnderPath } from "./nav-utils.ts";
+import { activeTabForRoute } from "./nav-utils.ts";
 import NavSelector from "./NavSelector.astro";
 import { resolveSlot } from "./overrides.ts";
 import Search from "./Search.astro";
@@ -94,6 +94,7 @@ const SearchSlot = resolveSlot(layout.Search, Search);
 // PageLayout) it's a tabs-only drawer the layout renders — so the button is also
 // needed whenever there are tabs to reveal.
 const showNavToggle = hasDrawer && (hasSidebar || navigation.tabs.length > 0);
+const activeTab = activeTabForRoute(navigation.tabs, route);
 // Where the header's inline tab bar appears. With a sidebar it shares the `md`
 // breakpoint with the docs drawer; without one, the tabs-only drawer is the sole
 // mobile nav below `lg`, so the inline tabs wait until `lg` to avoid duplicating
@@ -155,12 +156,7 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
       <nav aria-label={n.sections} class={tabsNavClass}>
         {navigation.tabs.map((tab) => (
           <a
-            aria-current={
-              route === tab.path ||
-              (tab.path !== "/" && isUnderPath(route, tab.path))
-                ? "page"
-                : undefined
-            }
+            aria-current={tab === activeTab ? "page" : undefined}
             class="rounded-full px-3 py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground aria-[current=page]:text-foreground"
             href={withBase(tab.path)}
           >

--- a/packages/blume/src/components/layout/PageLayout.astro
+++ b/packages/blume/src/components/layout/PageLayout.astro
@@ -39,7 +39,7 @@ import Favicon from "./Favicon.astro";
 import Fonts from "./Fonts.astro";
 import { BANNER_INIT_SCRIPT, THEME_INIT_SCRIPT } from "./head-scripts.ts";
 import Header from "./Header.astro";
-import { isUnderPath } from "./nav-utils.ts";
+import { activeTabForRoute } from "./nav-utils.ts";
 
 interface Props {
   site: { title: string; description?: string };
@@ -137,6 +137,7 @@ const searchLocale =
 const pageTitle = page?.title ?? site.title;
 const description = page?.description ?? site.description;
 const route = page?.route ?? "/";
+const activeTab = activeTabForRoute(navigation.tabs, route);
 
 // Derive canonical + og:image from the site URL the same way the catch-all does
 // for content pages, so a custom page gets both for free. The matching OG card
@@ -267,12 +268,7 @@ const bannerKey = banner?.dismissible ? banner.key : null;
                 {navigation.tabs.map((tab) => (
                   <li>
                     <a
-                      aria-current={
-                        route === tab.path ||
-                        (tab.path !== "/" && isUnderPath(route, tab.path))
-                          ? "page"
-                          : undefined
-                      }
+                      aria-current={tab === activeTab ? "page" : undefined}
                       class="block rounded-[0.65rem] px-2.5 py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground aria-[current=page]:bg-muted aria-[current=page]:text-foreground"
                       href={withBase(tab.path)}
                     >

--- a/packages/blume/src/components/layout/RootLayout.astro
+++ b/packages/blume/src/components/layout/RootLayout.astro
@@ -27,10 +27,10 @@ import { BANNER_INIT_SCRIPT, THEME_INIT_SCRIPT } from "./head-scripts.ts";
 import Header from "./Header.astro";
 import Icon from "../Icon.astro";
 import {
+  activeTabForRoute,
   findBreadcrumbs,
   flattenPages,
   getPagination,
-  isUnderPath,
   sidebarForRoute,
 } from "./nav-utils.ts";
 import NavTree from "./NavTree.astro";
@@ -307,6 +307,7 @@ const mcpUrl =
 // active tab's section, so a multi-section site drills each tab into its own
 // pages. Without tabs — or on a route under none — this is the full sidebar.
 const sidebar = sidebarForRoute(navigation.sidebar, navigation.tabs, page.route);
+const activeTab = activeTabForRoute(navigation.tabs, page.route);
 const crumbs = findBreadcrumbs(sidebar, page.route);
 const { prev, next } = getPagination(flattenPages(sidebar), page.route);
 
@@ -526,12 +527,7 @@ const bannerKey = banner?.dismissible ? banner.key : null;
                 {navigation.tabs.map((tab) => (
                   <li>
                     <a
-                      aria-current={
-                        page.route === tab.path ||
-                        (tab.path !== "/" && isUnderPath(page.route, tab.path))
-                          ? "page"
-                          : undefined
-                      }
+                      aria-current={tab === activeTab ? "page" : undefined}
                       class="block rounded-[0.65rem] px-2.5 py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground aria-[current=page]:bg-muted aria-[current=page]:text-foreground"
                       href={withBase(tab.path)}
                     >

--- a/packages/blume/src/components/layout/nav-utils.ts
+++ b/packages/blume/src/components/layout/nav-utils.ts
@@ -80,14 +80,16 @@ export const isUnderPath = (route: string, base: string): boolean =>
   base === "/" || route === base || route.startsWith(`${base}/`);
 
 /**
- * The tab whose `path` is the longest prefix of `route`, mirroring the header's
- * active-tab highlight. The root tab (`/`) is skipped — it spans everything and
- * so never scopes the sidebar.
+ * The tab whose `path` is the longest prefix of `route`. The root tab (`/`)
+ * acts as the fallback when no more specific tab matches.
  */
-const activeTab = (tabs: NavTab[], route: string): NavTab | null => {
+export const activeTabForRoute = (
+  tabs: NavTab[],
+  route: string
+): NavTab | null => {
   let match: NavTab | null = null;
   for (const tab of tabs) {
-    if (tab.path === "/" || !isUnderPath(route, tab.path)) {
+    if (!isUnderPath(route, tab.path)) {
       continue;
     }
     if (!match || tab.path.length > match.path.length) {
@@ -187,8 +189,8 @@ export const sidebarForRoute = (
   tabs: NavTab[],
   route: string
 ): NavNode[] => {
-  const tab = activeTab(tabs, route);
-  if (tab) {
+  const tab = activeTabForRoute(tabs, route);
+  if (tab && tab.path !== "/") {
     return sectionChildren(sidebar, tab.path) ?? [];
   }
   const scoped = withoutTabSections(sidebar, tabs);

--- a/packages/blume/test/nav-utils.test.ts
+++ b/packages/blume/test/nav-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { sidebarForRoute } from "../src/components/layout/nav-utils.ts";
+import {
+  activeTabForRoute,
+  sidebarForRoute,
+} from "../src/components/layout/nav-utils.ts";
 import type { NavNode, NavTab } from "../src/core/types.ts";
 
 const page = (label: string, route: string): NavNode => ({
@@ -32,6 +35,28 @@ const TABS: NavTab[] = [
 ];
 
 const labels = (nodes: NavNode[]): string[] => nodes.map((node) => node.label);
+
+describe("activeTabForRoute", () => {
+  it("uses the root tab as a fallback for child routes", () => {
+    const documentation: NavTab = { label: "Documentation", path: "/" };
+    const examples: NavTab = { label: "Examples", path: "/examples" };
+    const tabs = [documentation, examples];
+
+    expect(activeTabForRoute(tabs, "/guides/services")).toBe(documentation);
+  });
+
+  it("prefers the longest matching tab path", () => {
+    const documentation: NavTab = { label: "Documentation", path: "/" };
+    const examples: NavTab = { label: "Examples", path: "/examples" };
+    const tabs = [documentation, examples];
+
+    expect(activeTabForRoute(tabs, "/examples/hello-world")).toBe(examples);
+  });
+
+  it("returns null when no tab matches", () => {
+    expect(activeTabForRoute(TABS, "/changelog")).toBeNull();
+  });
+});
 
 describe("sidebarForRoute", () => {
   it("scopes to the active tab's section group", () => {


### PR DESCRIPTION
## Summary
- use one longest-path tab matcher across desktop and mobile navigation
- treat the root tab as the fallback when no more specific section matches
- add focused tests and a patch changeset

Closes #49.

## Test plan
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bunx bun@1.3.14 run test:coverage`
- [x] `bun run build`

Made with [Cursor](https://cursor.com)