### PR TITLE
Prevent themed logo layout shifts

### DIFF
--- a/.changeset/logo-layout-shift.md
+++ b/.changeset/logo-layout-shift.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Reserve space for local per-mode SVG logos before they load.

--- a/packages/blume/src/astro/generate.ts
+++ b/packages/blume/src/astro/generate.ts
@@ -626,7 +626,56 @@ const writeStagedContent = async (
   }
 };
 
-/** The logo shape the runtime consumes: an inline SVG or image URL(s). */
+interface LogoDimensions {
+  height: number;
+  width: number;
+}
+
+const SVG_ROOT = /<svg\b(?<attributes>[^>]*)>/u;
+const SVG_WIDTH = /\bwidth\s*=\s*["'](?<value>[^"']+)["']/u;
+const SVG_HEIGHT = /\bheight\s*=\s*["'](?<value>[^"']+)["']/u;
+const SVG_LENGTH = /^\s*(?<value>[\d.]+)(?:px)?\s*$/u;
+const SVG_VIEW_BOX =
+  /\bviewBox\s*=\s*["'][\d.-]+[\s,]+[\d.-]+[\s,]+(?<width>[\d.]+)[\s,]+(?<height>[\d.]+)["']/u;
+
+const parseSvgLength = (value: string | undefined): number | undefined => {
+  const length = Number(value?.match(SVG_LENGTH)?.groups?.value);
+  return length > 0 ? length : undefined;
+};
+
+/** Read dimensions from an SVG's explicit size or its view box. */
+const svgDimensions = (svg: string | undefined): LogoDimensions | undefined => {
+  const attributes = svg?.match(SVG_ROOT)?.groups?.attributes;
+  const width = parseSvgLength(attributes?.match(SVG_WIDTH)?.groups?.value);
+  const height = parseSvgLength(attributes?.match(SVG_HEIGHT)?.groups?.value);
+  if (width && height) {
+    return { height, width };
+  }
+
+  const viewBox = attributes?.match(SVG_VIEW_BOX);
+  const viewBoxWidth = Number(viewBox?.groups?.width);
+  const viewBoxHeight = Number(viewBox?.groups?.height);
+  return viewBoxWidth > 0 && viewBoxHeight > 0
+    ? { height: viewBoxHeight, width: viewBoxWidth }
+    : undefined;
+};
+
+/** Read a local SVG logo from the project root or public directory. */
+const readLogoSvg = (
+  project: BlumeProject,
+  source: string | undefined
+): string | undefined => {
+  if (!source?.toLowerCase().endsWith(".svg")) {
+    return;
+  }
+  const rel = source.replace(/^\//u, "");
+  const file = [
+    join(project.context.root, "public", rel),
+    join(project.context.root, rel),
+  ].find((path) => existsSync(path));
+  return file ? readFileSync(file, "utf-8") : undefined;
+};
+
 /**
  * Resolve the configured logo. A single SVG is read and inlined so a
  * `currentColor` logo follows the theme; other images keep their URL for an
@@ -647,18 +696,20 @@ const resolveLogo = (project: BlumeProject): BlumeLogo | null => {
   const dark = image?.dark ?? image?.light;
   const alt = image?.alt ?? "";
   const brandHref = href ?? "/";
+  const lightSvg = readLogoSvg(project, light);
+  const darkSvg = dark === light ? lightSvg : readLogoSvg(project, dark);
 
-  if (light && light === dark && light.toLowerCase().endsWith(".svg")) {
-    const rel = light.replace(/^\//u, "");
-    const file = [
-      join(project.context.root, "public", rel),
-      join(project.context.root, rel),
-    ].find((path) => existsSync(path));
-    if (file) {
-      return { alt, href: brandHref, svg: readFileSync(file, "utf-8"), text };
-    }
+  if (light && light === dark && lightSvg) {
+    return { alt, href: brandHref, svg: lightSvg, text };
   }
-  return { alt, dark, href: brandHref, light, text };
+
+  const lightDimensions = svgDimensions(lightSvg);
+  const darkDimensions = svgDimensions(darkSvg);
+  const dimensions =
+    lightDimensions || darkDimensions
+      ? { dark: darkDimensions, light: lightDimensions }
+      : undefined;
+  return { alt, dark, dimensions, href: brandHref, light, text };
 };
 
 /**

--- a/packages/blume/src/components/layout/Logo.astro
+++ b/packages/blume/src/components/layout/Logo.astro
@@ -18,6 +18,8 @@ const { site, logo } = Astro.props;
 const logoSvg = logo?.svg;
 const logoLight = logo?.light;
 const logoDark = logo?.dark ?? logo?.light;
+const logoLightDimensions = logo?.dimensions?.light;
+const logoDarkDimensions = logo?.dimensions?.dark ?? logo?.dimensions?.light;
 const logoAlt = logo?.alt ?? "";
 const brandHref = logo?.href ?? "/";
 // Wordmark beside the mark: the configured `logo.text`, or the site title when
@@ -43,18 +45,28 @@ const brandText = logo?.text ?? site.title;
     !logoSvg &&
       logoLight &&
       (logoLight === logoDark ? (
-        <img alt={logoAlt} class="h-5 w-auto" src={withBase(logoLight)} />
+        <img
+          alt={logoAlt}
+          class="h-5 w-auto"
+          height={logoLightDimensions?.height}
+          src={withBase(logoLight)}
+          width={logoLightDimensions?.width}
+        />
       ) : (
         <>
           <img
             alt={logoAlt}
             class="h-5 w-auto dark:hidden"
+            height={logoLightDimensions?.height}
             src={withBase(logoLight)}
+            width={logoLightDimensions?.width}
           />
           <img
             alt={logoAlt}
             class="hidden h-5 w-auto dark:block"
+            height={logoDarkDimensions?.height}
             src={withBase(logoDark)}
+            width={logoDarkDimensions?.width}
           />
         </>
       ))

--- a/packages/blume/src/core/data.ts
+++ b/packages/blume/src/core/data.ts
@@ -15,6 +15,10 @@ export interface BlumeLogo {
   svg?: string;
   light?: string;
   dark?: string;
+  dimensions?: {
+    dark?: { height: number; width: number };
+    light?: { height: number; width: number };
+  };
   alt: string;
   href: string;
   /** Wordmark text beside the mark; `undefined` falls back to the site title. */

--- a/packages/blume/test/generate.test.ts
+++ b/packages/blume/test/generate.test.ts
@@ -295,6 +295,25 @@ describe("buildRuntimeData", () => {
     expect(data.config.logo.href).toBe("/");
   });
 
+  it("reserves dimensions for per-mode SVG logos", async () => {
+    const project = await scanProject(
+      await writeProject({
+        "blume.config.ts": `export default {
+  logo: { image: { dark: "/dark.svg", light: "/light.svg" } },
+};
+`,
+        "docs/index.md": "# Home\n",
+        "public/dark.svg": '<svg viewBox="0 0 608 96"></svg>',
+        "public/light.svg": '<svg height="191" width="1214"></svg>',
+      })
+    );
+    const data = JSON.parse(buildRuntimeData(project));
+    expect(data.config.logo.dimensions).toEqual({
+      dark: { height: 96, width: 608 },
+      light: { height: 191, width: 1214 },
+    });
+  });
+
   it("falls back to an <img> logo when the SVG file is absent", async () => {
     const project = await scanProject(
       await writeProject({


### PR DESCRIPTION
## Summary
- read dimensions from local light and dark SVG logos at build time
- emit intrinsic dimensions on logo images so the header stays stable before load
- cover explicit dimensions and view boxes in tests

Closes #52.

## Test plan
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bunx bun@1.3.14 run test:coverage`
- [x] `bun run build`