### PR TITLE
Add Open Graph card branding

### DIFF
--- a/.changeset/og-card-branding.md
+++ b/.changeset/og-card-branding.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Add custom logo and palette settings for generated Open Graph cards.

--- a/apps/docs/content/docs/configuration/seo.mdx
+++ b/apps/docs/content/docs/configuration/seo.mdx
@@ -106,7 +106,26 @@ seo: {
 }
 ```
 
-Each card is derived from your content and theme — the **page title** as the headline, your **site title** as the eyebrow, and your theme **accent** for the mark. Images are served at `/og/<slug>.png`, mirroring each route, and are prerendered as static files even in server mode:
+### Brand the generated card
+
+Set a local SVG and hex palette to match the generated card to your brand. The logo can live in `public/` or at the project root. Omit any palette value to keep its default.
+
+```ts blume.config.ts lineNumbers
+seo: {
+  og: {
+    logo: "/logo/og.svg",
+    palette: {
+      accent: "#ff5410",
+      background: "#1d1d1d",
+      foreground: "#fff6f2",
+      muted: "#a6a19f",
+      border: "#323232",
+    },
+  },
+}
+```
+
+By default, each card is derived from your content and theme — the **page title** as the headline, your **site title** as the eyebrow, and your theme **accent** for the mark. Images are served at `/og/<slug>.png`, mirroring each route, and are prerendered as static files even in server mode:
 
 | Page route          | Image URL                  |
 | ------------------- | -------------------------- |

--- a/packages/blume/src/astro/generate.ts
+++ b/packages/blume/src/astro/generate.ts
@@ -37,6 +37,7 @@ import { resolveDocsCollection } from "../core/sources/resolve.ts";
 import { resolveTsconfigAliases } from "../core/tsconfig-aliases.ts";
 import type { Navigation } from "../core/types.ts";
 import { buildRssFeeds, renderRssFeed } from "../deploy/rss.ts";
+import { resolveOgLogo } from "../og/logo.ts";
 import { hasScalarReferences, referenceTabs } from "../openapi/references.ts";
 import { buildReferenceFiles } from "../openapi/scalar.ts";
 import { isOpenApiSource } from "../openapi/source.ts";
@@ -779,6 +780,10 @@ export const buildRuntimeData = (project: BlumeProject): string => {
     ? `https://github.com/${github.owner}/${github.repo}`
     : null;
   const editBase = github ? `${repoUrl}/edit/${github.branch}` : null;
+  const logo = resolveLogo(project);
+  const ogLogo = config.seo.og.logo
+    ? resolveOgLogo(project, config.seo.og.logo)
+    : logo?.svg;
 
   const editUrlFor = (sourcePath?: string): string | null => {
     if (!(editBase && sourcePath)) {
@@ -865,7 +870,7 @@ export const buildRuntimeData = (project: BlumeProject): string => {
           }
         : null,
       imageZoom: config.markdown.imageZoom,
-      logo: resolveLogo(project),
+      logo,
       mcp: config.ai.mcp.enabled
         ? {
             name: config.ai.mcp.name ?? config.title,
@@ -874,7 +879,11 @@ export const buildRuntimeData = (project: BlumeProject): string => {
         : null,
       // `og.enabled` is resolved to a definite boolean in `loadConfig`; coerce
       // the optional schema type so the serialized shape stays `boolean`.
-      og: { enabled: config.seo.og.enabled ?? false },
+      og: {
+        enabled: config.seo.og.enabled ?? false,
+        logo: ogLogo,
+        palette: config.seo.og.palette,
+      },
       repoUrl,
       search: {
         enabled: config.search.provider !== "none",

--- a/packages/blume/src/astro/templates.ts
+++ b/packages/blume/src/astro/templates.ts
@@ -1034,10 +1034,11 @@ const siteHost = (() => {
 
 export async function GET({ props }) {
   const png = await renderOgImage({
-    accent: data.config.theme.accent.light,
+    accent: data.config.og.palette?.accent ?? data.config.theme.accent.light,
     brand: data.config.title,
     description: data.config.description,
-    logo: data.config.logo?.svg,
+    logo: data.config.og.logo,
+    palette: data.config.og.palette,
     repo: repoSlug,
     site: siteHost,
     title: props.title,

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -711,6 +711,34 @@ export interface RssConfig {
   types?: string[];
 }
 
+/** Colors used by generated Open Graph cards. Values must be hex colors. */
+export interface OgPaletteConfig {
+  /** Fallback mark color. Defaults to the light theme accent. */
+  accent?: string;
+  /** Card background. */
+  background?: string;
+  /** Footer divider. */
+  border?: string;
+  /** Headline and `currentColor` logo color. */
+  foreground?: string;
+  /** Description and footer text. */
+  muted?: string;
+}
+
+/** Per-page Open Graph image generation. */
+export interface OgConfig {
+  /**
+   * Generate an OG image per page. Defaults to on once a deployment `site`
+   * URL is known and off otherwise (`og:image` must be absolute). An explicit
+   * value always wins.
+   */
+  enabled?: boolean;
+  /** Local SVG used in the generated card instead of the site logo. */
+  logo?: string;
+  /** Optional generated-card colors. */
+  palette?: OgPaletteConfig;
+}
+
 /** Discoverability: OG images, feeds, sitemap, robots, and structured data. */
 export interface SeoConfig {
   /**
@@ -721,14 +749,7 @@ export interface SeoConfig {
   /** robots.txt `Content-Signal` usage declaration. Defaults to `true`. */
   contentSignals?: ContentSignalsConfig;
   /** Per-page Open Graph image generation. */
-  og?: {
-    /**
-     * Generate an OG image per page. Defaults to on once a deployment `site`
-     * URL is known and off otherwise (`og:image` must be absolute). An explicit
-     * value always wins.
-     */
-    enabled?: boolean;
-  };
+  og?: OgConfig;
   /** Generate robots.txt (with a Sitemap reference when available). Defaults to `true`. */
   robots?: boolean;
   /** RSS/Atom feeds. */

--- a/packages/blume/src/core/data.ts
+++ b/packages/blume/src/core/data.ts
@@ -109,7 +109,11 @@ export interface BlumeDataConfig {
   /** Hosted MCP server, or `null` when MCP is off. */
   mcp: { name: string; route: string } | null;
   /** Open Graph image generation. */
-  og: { enabled: boolean };
+  og: {
+    enabled: boolean;
+    logo?: string;
+    palette?: ResolvedConfig["seo"]["og"]["palette"];
+  };
   /** Repository URL for header/edit links, or `null`. */
   repoUrl: string | null;
   search: { enabled: boolean; provider: SearchProvider };

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -802,6 +802,18 @@ const xConfigSchema = z.strictObject({
   handle: xHandleSchema,
 });
 
+const ogColorSchema = z
+  .string()
+  .regex(/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/iu);
+
+const ogPaletteSchema = z.strictObject({
+  accent: ogColorSchema.optional(),
+  background: ogColorSchema.optional(),
+  border: ogColorSchema.optional(),
+  foreground: ogColorSchema.optional(),
+  muted: ogColorSchema.optional(),
+});
+
 const ogConfigSchema = z.strictObject({
   /**
    * Generate a per-page Open Graph image. Defaults to on once a deployment
@@ -810,6 +822,10 @@ const ogConfigSchema = z.strictObject({
    * `loadConfig`. An explicit value here always wins.
    */
   enabled: z.boolean().optional(),
+  /** Local SVG used in the generated card instead of the site logo. */
+  logo: z.string().optional(),
+  /** Optional generated-card colors. */
+  palette: ogPaletteSchema.optional(),
 });
 
 const rssConfigSchema = z.strictObject({

--- a/packages/blume/src/og/card.ts
+++ b/packages/blume/src/og/card.ts
@@ -35,6 +35,17 @@ const resolveAccent = (accent: string): string => {
   return HEX_COLOR.test(accent) ? accent : "#3b82f6";
 };
 
+const resolveColor = (color: string | undefined, fallback: string): string =>
+  color && HEX_COLOR.test(color) ? color : fallback;
+
+export interface OgCardPalette {
+  accent?: string;
+  background?: string;
+  border?: string;
+  foreground?: string;
+  muted?: string;
+}
+
 export interface OgCardOptions {
   /** Large headline — the page title. */
   title: string;
@@ -45,10 +56,12 @@ export interface OgCardOptions {
   /** Muted subtitle under the headline (usually the site description). */
   description?: string;
   /**
-   * Inlined SVG markup of the configured logo (`config.logo.svg`), painted into
+   * Inlined SVG markup of the configured logo, painted into
    * the brand lockup. Falls back to an accent mark when absent.
    */
   logo?: string;
+  /** Optional colors for the generated card. */
+  palette?: OgCardPalette;
   /** Footer-left repository slug, e.g. `owner/repo`. */
   repo?: string;
   /** Footer-right site host, e.g. `docs.acme.com`. */
@@ -66,6 +79,17 @@ const FOREGROUND = "#0a0a0a";
 const MUTED = "#737373";
 const FAINT = "#a3a3a3";
 const BORDER = "#e5e5e5";
+
+const resolvePalette = (
+  options: OgCardOptions
+): Required<OgCardPalette> & { faint: string } => ({
+  accent: resolveAccent(options.palette?.accent ?? options.accent ?? "blue"),
+  background: resolveColor(options.palette?.background, BG),
+  border: resolveColor(options.palette?.border, BORDER),
+  faint: resolveColor(options.palette?.muted, FAINT),
+  foreground: resolveColor(options.palette?.foreground, FOREGROUND),
+  muted: resolveColor(options.palette?.muted, MUTED),
+});
 
 /**
  * Truncate to `max` code points with an ellipsis. Slices by code points, not
@@ -103,8 +127,8 @@ const logoAspect = (svg: string): number | null => {
 // Render the configured logo as the brand mark. A `currentColor` logo carries
 // no intrinsic color, so it is painted in the foreground to read on the light
 // card, then handed to Takumi as a data URI sized from the SVG's aspect ratio.
-const logoMark = (svg: string): Node => {
-  const painted = svg.replaceAll("currentColor", FOREGROUND);
+const logoMark = (svg: string, foreground: string): Node => {
+  const painted = svg.replaceAll("currentColor", foreground);
   const aspect = logoAspect(painted);
   let height = MARK_HEIGHT;
   let width = aspect ? MARK_HEIGHT * aspect : MARK_HEIGHT;
@@ -151,7 +175,8 @@ const titleSize = (title: string): number => {
 
 /** Render a 1200x630 Open Graph card to a PNG buffer. */
 export const renderOgImage = (options: OgCardOptions): Promise<Buffer> => {
-  const accent = resolveAccent(options.accent ?? "blue");
+  const { accent, background, border, faint, foreground, muted } =
+    resolvePalette(options);
   const brand = options.brand?.trim();
   const logo = options.logo?.trim();
   // Slice by code point, not code unit — `charAt(0)` would split a leading
@@ -166,14 +191,16 @@ export const renderOgImage = (options: OgCardOptions): Promise<Buffer> => {
   // ("Ultracite  Ultracite"). Without a logo, the accent tile with the brand
   // initial stands in.
   const header = container({
-    children: [logo ? logoMark(logo) : initialMark(accent, initial)],
+    children: [
+      logo ? logoMark(logo, foreground) : initialMark(accent, initial),
+    ],
     style: { alignItems: "center", display: "flex" },
   });
 
   const body = container({
     children: [
       text(truncate(options.title, 64), {
-        color: FOREGROUND,
+        color: foreground,
         fontSize: titleSize(options.title),
         fontWeight: 600,
         letterSpacing: "-0.03em",
@@ -183,7 +210,7 @@ export const renderOgImage = (options: OgCardOptions): Promise<Buffer> => {
       }),
       description
         ? text(truncate(description, 140), {
-            color: MUTED,
+            color: muted,
             fontSize: 30,
             lineHeight: 1.4,
             marginTop: 28,
@@ -200,15 +227,15 @@ export const renderOgImage = (options: OgCardOptions): Promise<Buffer> => {
       ? container({
           children: [
             container({
-              style: { backgroundColor: BORDER, height: 1, width: "100%" },
+              style: { backgroundColor: border, height: 1, width: "100%" },
             }),
             container({
               children: [
                 repo
-                  ? text(repo, { color: MUTED, fontSize: 22 })
+                  ? text(repo, { color: muted, fontSize: 22 })
                   : container({}),
                 site
-                  ? text(site, { color: FAINT, fontSize: 22 })
+                  ? text(site, { color: faint, fontSize: 22 })
                   : container({}),
               ],
               style: {
@@ -227,8 +254,8 @@ export const renderOgImage = (options: OgCardOptions): Promise<Buffer> => {
   const node = container({
     children: [header, body, footer],
     style: {
-      backgroundColor: BG,
-      color: FOREGROUND,
+      backgroundColor: background,
+      color: foreground,
       display: "flex",
       flexDirection: "column",
       height: HEIGHT,

--- a/packages/blume/src/og/index.ts
+++ b/packages/blume/src/og/index.ts
@@ -1,2 +1,2 @@
 export { renderOgImage } from "./card.ts";
-export type { OgCardOptions } from "./card.ts";
+export type { OgCardOptions, OgCardPalette } from "./card.ts";

--- a/packages/blume/src/og/logo.ts
+++ b/packages/blume/src/og/logo.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { join } from "pathe";
+
+import type { BlumeProject } from "../core/project-graph.ts";
+
+/** Resolve a configured local SVG for use in generated Open Graph cards. */
+export const resolveOgLogo = (
+  project: BlumeProject,
+  source: string | undefined
+): string | undefined => {
+  if (!source?.toLowerCase().endsWith(".svg")) {
+    return;
+  }
+  const relative = source.replace(/^\//u, "");
+  const file = [
+    join(project.context.root, "public", relative),
+    join(project.context.root, relative),
+  ].find((path) => existsSync(path));
+  return file ? readFileSync(file, "utf-8") : undefined;
+};

--- a/packages/blume/test/core.test.ts
+++ b/packages/blume/test/core.test.ts
@@ -106,6 +106,30 @@ describe("config schema", () => {
     ).toBeFalsy();
   });
 
+  it("accepts Open Graph branding and rejects non-hex palette colors", () => {
+    const { og } = blumeConfigSchema.parse({
+      seo: {
+        og: {
+          logo: "/og-logo.svg",
+          palette: {
+            accent: "#ff5410",
+            background: "#1d1d1d",
+            border: "#323232",
+            foreground: "#fff6f2",
+            muted: "#a6a19f",
+          },
+        },
+      },
+    }).seo;
+    expect(og.logo).toBe("/og-logo.svg");
+    expect(og.palette?.background).toBe("#1d1d1d");
+    expect(
+      blumeConfigSchema.safeParse({
+        seo: { og: { palette: { background: "black" } } },
+      }).success
+    ).toBeFalsy();
+  });
+
   it("normalizes seo.x handles to a leading @", () => {
     // `twitter:site`/`twitter:creator` require the `@`; a handle configured
     // without one is the obvious typo to absorb rather than reject.

--- a/packages/blume/test/generate.test.ts
+++ b/packages/blume/test/generate.test.ts
@@ -293,6 +293,52 @@ describe("buildRuntimeData", () => {
     const data = JSON.parse(buildRuntimeData(project));
     expect(data.config.logo.svg).toContain('id="brand"');
     expect(data.config.logo.href).toBe("/");
+    expect(data.config.og.logo).toContain('id="brand"');
+  });
+
+  it("resolves custom Open Graph branding", async () => {
+    const project = await scanProject(
+      await writeProject({
+        "blume.config.ts": `export default {
+  seo: {
+    og: {
+      logo: "/og-logo.svg",
+      palette: {
+        accent: "#ff5410",
+        background: "#1d1d1d",
+        border: "#323232",
+        foreground: "#fff6f2",
+        muted: "#a6a19f",
+      },
+    },
+  },
+};
+`,
+        "docs/index.md": "# Home\n",
+        "public/og-logo.svg": '<svg id="og-brand"></svg>',
+      })
+    );
+    const data = JSON.parse(buildRuntimeData(project));
+    expect(data.config.og.logo).toContain('id="og-brand"');
+    expect(data.config.og.palette).toEqual({
+      accent: "#ff5410",
+      background: "#1d1d1d",
+      border: "#323232",
+      foreground: "#fff6f2",
+      muted: "#a6a19f",
+    });
+  });
+
+  it("ignores a non-SVG Open Graph logo", async () => {
+    const project = await scanProject(
+      await writeProject({
+        "blume.config.ts":
+          'export default { seo: { og: { logo: "/logo.png" } } };\n',
+        "docs/index.md": "# Home\n",
+      })
+    );
+    const data = JSON.parse(buildRuntimeData(project));
+    expect(data.config.og.logo).toBeUndefined();
   });
 
   it("falls back to an <img> logo when the SVG file is absent", async () => {

--- a/packages/blume/test/og-card.test.ts
+++ b/packages/blume/test/og-card.test.ts
@@ -53,6 +53,24 @@ describe("renderOgImage", () => {
     });
   });
 
+  it("renders a custom logo and palette", async () => {
+    await expectPng({
+      brand: "Acme",
+      description: "Branded documentation.",
+      logo: SQUARE_LOGO,
+      palette: {
+        accent: "#ff5410",
+        background: "#1d1d1d",
+        border: "#323232",
+        foreground: "#fff6f2",
+        muted: "#a6a19f",
+      },
+      repo: "acme/docs",
+      site: "docs.acme.com",
+      title: "Getting started",
+    });
+  });
+
   it("scales down a wide wordmark logo and a long title", async () => {
     await expectPng({ logo: WIDE_LOGO, title: LONG_TITLE });
   });

--- a/packages/blume/test/templates.test.ts
+++ b/packages/blume/test/templates.test.ts
@@ -1114,7 +1114,10 @@ describe("static endpoint templates", () => {
   });
 
   it("renders the OG image endpoint", () => {
-    expect(ogEndpointTemplate()).toContain("renderOgImage");
+    const endpoint = ogEndpointTemplate();
+    expect(endpoint).toContain("renderOgImage");
+    expect(endpoint).toContain("logo: data.config.og.logo");
+    expect(endpoint).toContain("palette: data.config.og.palette");
   });
 
   it("serves one RSS feed per section", () => {


### PR DESCRIPTION
## Summary
- add optional local SVG and hex palette settings under `seo.og`
- pass resolved branding into generated cards while preserving current defaults
- document the config and cover schema, generation, templates, and rendering

Closes #54.

## Test plan
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bunx bun@1.3.14 run test:coverage`
- [x] `bun run build`
- [x] render a card with a custom logo and palette