### PR TITLE
Hide language icon on header-less standalone code blocks

### DIFF
--- a/.changeset/codeblock-icon-overlap.md
+++ b/.changeset/codeblock-icon-overlap.md
@@ -1,0 +1,7 @@
+---
+"blume": patch
+---
+
+Gate the language icon on `data-language` so it no longer overlaps the first code line on header-less standalone `<CodeBlock>`s. The icon transformer runs whenever icons are on, but a standalone block without a `title` never gets `data-language` (the header bar that reserves the icon's space), so the absolutely-positioned icon sat on top of the first line. Fenced code and titled blocks are unaffected.
+
+Fixes #56.

--- a/apps/docs/content/docs/content/components.mdx
+++ b/apps/docs/content/docs/content/components.mdx
@@ -619,7 +619,6 @@ An Astro example renders live with no client JavaScript:
 
 <CodeBlock
   lang="ts"
-  icons={false}
   code={`export const greet = (name: string): string =>
   \`Hello, \${name}!\`;`}
 />
@@ -629,7 +628,7 @@ An Astro example renders live with no client JavaScript:
 import CodeBlock from "blume/components/content/CodeBlock.astro";
 ---
 
-<CodeBlock lang="ts" code={source} icons={false} />
+<CodeBlock lang="ts" code={source} />
 ```
 
 To highlight to an HTML string yourself (e.g. inside your own component), import the underlying helper from `blume/markdown`:

--- a/packages/blume/src/markdown/language-icon.ts
+++ b/packages/blume/src/markdown/language-icon.ts
@@ -7,7 +7,8 @@
  * hex colors are skipped because dark-on-dark logos (Next.js, Rust…) vanish.
  *
  * The theme styles `.blume-lang-icon` and shifts the language label
- * (`pre[data-icon]::before`) to make room.
+ * (`pre[data-language][data-icon]::before`) to make room — gated on
+ * `data-language` so the icon only shows when a header bar exists to hold it.
  */
 
 import {

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -386,13 +386,16 @@ blume-diff {
 
 /* Language icon (simple-icons) sits at the header's left edge; the label shifts
    right to make room. Injected at build time by the language-icon transformer.
-   Shown only for top-level prose blocks, which have a header — flush code in
-   tabs and API panels is nested deeper, so the child combinator skips it. */
+   The icon is gated on data-language (the header bar), not just data-icon: the
+   transformer runs whenever icons are on, but a header-less standalone
+   CodeBlock (no title) never gets data-language, so without this gate the
+   absolutely-positioned icon would overlap the first code line. Fenced code
+   and titled blocks always have a header, so the icon shows there. */
 .blume-lang-icon {
   display: none;
 }
 
-.prose > :where(pre[data-icon]) > .blume-lang-icon {
+.prose > :where(pre[data-language][data-icon]) > .blume-lang-icon {
   color: var(--blume-muted-foreground);
   display: block;
   height: 0.875rem;
@@ -402,7 +405,7 @@ blume-diff {
   width: 0.875rem;
 }
 
-.prose > :where(pre[data-icon])::before {
+.prose > :where(pre[data-language][data-icon])::before {
   padding-left: 2.5rem;
 }
 

--- a/packages/blume/test/markdown.test.ts
+++ b/packages/blume/test/markdown.test.ts
@@ -816,6 +816,17 @@ describe("highlightCode", () => {
     expect(html).toContain('data-title="file.ts"');
   });
 
+  it("omits data-language on the header-less path so the icon gate hides it", async () => {
+    // The icon transformer still runs (data-icon is set), but without a title
+    // there's no header bar (data-language), so the theme's `pre[data-language]
+    // [data-icon]` gate keeps the absolutely-positioned icon from overlapping
+    // the first code line. See https://github.com/haydenbleasel/blume/issues/56
+    const html = await highlightCode("const x = 1;", "ts");
+    expect(html).not.toContain("data-language");
+    expect(html).toContain("data-icon");
+    expect(html).toContain("blume-lang-icon");
+  });
+
   it("applies an extra className to the <pre>", async () => {
     const html = await highlightCode("const x = 1;", "ts", {
       className: "blume-source",


### PR DESCRIPTION
## Summary

- Gates the language-icon display rule on `data-language` (the header bar) instead of just `data-icon`, so the icon no longer overlaps the first code line on a header-less standalone `<CodeBlock>`.
- The icon transformer runs whenever icons are on, but a standalone `<CodeBlock>` without a `title` never gets `data-language` (the header that reserves the icon's space via `padding-top`), so the absolutely-positioned icon sat on top of the first line. Fenced code gets `data-language` from Shiki automatically, and titled blocks get it from `languageAttrTransformer` — both keep the header, so the icon still shows there.
- One-line CSS change in `packages/blume/src/theme/entry.ts` (two selectors gain a `data-language` qualifier), plus a regression test.

Fixes #56.

## Root cause

- `languageIconTransformer` (`packages/blume/src/markdown/language-icon.ts`) injects the `<svg class="blume-lang-icon">` and sets `data-icon` on `<pre>` whenever `icons !== false` — independent of whether a title/header exists.
- The header bar that reserves room for the icon is keyed off `pre[data-language]` (`packages/blume/src/theme/entry.ts`): `pre[data-language] { padding-top: 3.75rem }` and the `::before` label.
- On the standalone `highlightCode` path, `data-language` is only added by `languageAttrTransformer`, which runs **only when a `title` is passed** (`packages/blume/src/markdown/index.ts`). Fenced code is unaffected because Shiki sets `data-language` itself.
- Net effect: header-less standalone block → `data-icon` set, `data-language` absent → no header padding → the absolutely-positioned icon (`top: 0.875rem`) overlaps the first code line.

## Fix

Scope the icon display (and the label `padding-left` shift) to `pre[data-language][data-icon]`, so the icon renders only when a header bar exists to hold it. This matches the existing comment's stated intent ("Shown only for top-level prose blocks, which have a header") and leaves fenced code, titled blocks, tabs, and API panels untouched.

```diff
-.prose > :where(pre[data-icon]) > .blume-lang-icon {
+.prose > :where(pre[data-language][data-icon]) > .blume-lang-icon {
   ...
 }
-.prose > :where(pre[data-icon])::before {
+.prose > :where(pre[data-language][data-icon])::before {
   padding-left: 2.5rem;
 }
```

## Test plan

- [x] `bun run test` — 1399 pass, 0 fail (includes a new regression test asserting the header-less path omits `data-language` while still emitting `data-icon`/`blume-lang-icon`).
- [x] `bun run check` — formatting clean.
- [x] `bun run build` (via pre-commit/turbo) — succeeds.
- [x] Reviewer: confirm a header-less `<CodeBlock lang="ts" code="..." />` no longer shows an overlapping icon, and that fenced + titled blocks still render the icon.