### PR TITLE
Match native controls to active theme

### DIFF
--- a/.changeset/quiet-scrollbars-smile.md
+++ b/.changeset/quiet-scrollbars-smile.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Match native browser controls, including scrollbars, to the active color theme.

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -159,9 +159,13 @@ ${THEME_MAPPING}
     cursor: pointer;
   }
   html {
+    color-scheme: light;
     scroll-behavior: smooth;
     scroll-padding-top: 4.5rem;
     text-rendering: optimizeLegibility;
+  }
+  html[data-theme="dark"] {
+    color-scheme: dark;
   }
   /* Headings use the display font (defaults to the body font when unset). */
   h1,

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -16,6 +16,15 @@ interface TailwindEntryOptions {
 const DARK_VARIANT = `/* Dark mode is driven by data-theme on the <html> element. */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));`;
 
+/** Keep browser-provided UI in sync with the active theme in both sheets. */
+const COLOR_SCHEME_DEFAULTS = `:root {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+}`;
+
 /**
  * The default `--blume-*` design tokens (light + dark), shared by the app
  * sheet and the isolated example-preview sheet so previews inherit the site's
@@ -141,6 +150,8 @@ ${options.sources.map((source) => `@source "${source}";`).join("\n")}
 
 ${DARK_VARIANT}
 
+${COLOR_SCHEME_DEFAULTS}
+
 ${TOKEN_DEFAULTS}
 
 ${THEME_MAPPING}
@@ -159,13 +170,9 @@ ${THEME_MAPPING}
     cursor: pointer;
   }
   html {
-    color-scheme: light;
     scroll-behavior: smooth;
     scroll-padding-top: 4.5rem;
     text-rendering: optimizeLegibility;
-  }
-  html[data-theme="dark"] {
-    color-scheme: dark;
   }
   /* Headings use the display font (defaults to the body font when unset). */
   h1,
@@ -720,6 +727,8 @@ export const examplesEntryTemplate = (options: ExamplesEntryOptions): string =>
 ${options.sources.map((source) => `@source "${source}";`).join("\n")}
 
 ${DARK_VARIANT}
+
+${COLOR_SCHEME_DEFAULTS}
 
 ${TOKEN_DEFAULTS}
 

--- a/packages/blume/test/theme.test.ts
+++ b/packages/blume/test/theme.test.ts
@@ -159,11 +159,12 @@ describe("tailwindEntryTemplate", () => {
   });
 
   it("matches native controls to the active color theme", () => {
-    expect(entry).toContain(`html {
-    color-scheme: light;`);
-    expect(entry).toContain(`html[data-theme="dark"] {
-    color-scheme: dark;
-  }`);
+    expect(entry).toContain(`:root {
+  color-scheme: light;
+}`);
+    expect(entry).toContain(`:root[data-theme="dark"] {
+  color-scheme: dark;
+}`);
   });
 
   it("appends config tokens before the user theme (user wins)", () => {
@@ -226,6 +227,15 @@ describe("examplesEntryTemplate", () => {
     expect(entry).not.toContain(".prose");
     expect(entry).not.toContain("@plugin");
     expect(entry).not.toContain("blume-tabs");
+  });
+
+  it("matches native controls to the active color theme", () => {
+    expect(entry).toContain(`:root {
+  color-scheme: light;
+}`);
+    expect(entry).toContain(`:root[data-theme="dark"] {
+  color-scheme: dark;
+}`);
   });
 
   it("appends config tokens before the user examples css (user wins)", () => {

--- a/packages/blume/test/theme.test.ts
+++ b/packages/blume/test/theme.test.ts
@@ -158,6 +158,14 @@ describe("tailwindEntryTemplate", () => {
     expect(entry).toContain('[data-theme="dark"]');
   });
 
+  it("matches native controls to the active color theme", () => {
+    expect(entry).toContain(`html {
+    color-scheme: light;`);
+    expect(entry).toContain(`html[data-theme="dark"] {
+    color-scheme: dark;
+  }`);
+  });
+
   it("appends config tokens before the user theme (user wins)", () => {
     const configAt = entry.indexOf("--blume-accent: red;");
     const userAt = entry.indexOf(".prose { color: green; }");


### PR DESCRIPTION
## Summary

- match native browser controls, including scrollbars, to Blume's active color theme
- emit the shared `:root` color-scheme defaults in both the docs shell and isolated example previews
- use Blume's existing `data-theme` contract instead of introducing a custom scroll area
- add focused regression coverage and a patch changeset

Fixes #40.

## Root cause

Blume updates `data-theme` on the root element, but the generated theme stylesheets did not set `color-scheme`. Native controls therefore continued using the browser's default light appearance in dark mode.

## Screenshots

### Before

![Light scrollbar in dark mode](https://github.com/user-attachments/assets/3fdc2764-8638-4924-863e-e4d3c29fc707)

### After — dark theme

![Dark scrollbar matching dark theme](https://raw.githubusercontent.com/FranciscoMoretti/blume/b7cc74ef03e0ba8c973f88f2d1f49f6164d7f763/dark-theme.png)

### After — light theme

![Light scrollbar matching light theme](https://raw.githubusercontent.com/FranciscoMoretti/blume/b7cc74ef03e0ba8c973f88f2d1f49f6164d7f763/light-theme.png)

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run test:coverage` — 1,400 passed, 0 failed
- `bun run build --filter=!video --filter blume`
- verified the overflowing sidebar renders with `color-scheme: dark` in dark mode
- toggled to light mode and verified `color-scheme: light`
- no browser console warnings or errors
