### PR TITLE
Match prose bullets to counters (muted-foreground)

### DIFF
--- a/.changeset/prose-bullets-muted-foreground.md
+++ b/.changeset/prose-bullets-muted-foreground.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Match unordered-list bullets to ordered-list numbers in prose. `--tw-prose-bullets` now defaults to `--blume-muted-foreground` (like `--tw-prose-counters`) instead of `--blume-border`, which rendered bullets much lighter than the numbers beside them.

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -222,7 +222,7 @@ ${THEME_MAPPING}
   --tw-prose-links: var(--blume-foreground);
   --tw-prose-bold: var(--blume-foreground);
   --tw-prose-counters: var(--blume-muted-foreground);
-  --tw-prose-bullets: var(--blume-border);
+  --tw-prose-bullets: var(--blume-muted-foreground);
   --tw-prose-hr: var(--blume-border);
   --tw-prose-quotes: var(--blume-muted-foreground);
   --tw-prose-quote-borders: var(--blume-border);


### PR DESCRIPTION
Small theme fix: unordered-list bullets are noticeably lighter than the numbers in an ordered list, because the two markers pull from different tokens.

In `theme/entry.ts`:

```css
--tw-prose-counters: var(--blume-muted-foreground);
--tw-prose-bullets: var(--blume-border);   /* much lighter */
```

On the default light palette that's `oklch(0.552 …)` for numbers vs `oklch(0.92 …)` for bullets — the bullets nearly wash out on white. This points `--tw-prose-bullets` at `--blume-muted-foreground` too, so both markers match in light and dark.

Scoped to the one line; a patch changeset is included. Happy to adjust the token choice if you'd prefer bullets stay distinct — thanks for Blume! 🙏