### PR TITLE
Themeable content-column width via `max-w-content`

### DIFF
--- a/.changeset/themeable-content-width.md
+++ b/.changeset/themeable-content-width.md
@@ -1,5 +1,5 @@
 ---
-"blume": minor
+"blume": patch
 ---
 
 Add a themeable content-column width. A new `--blume-content-width` token (default `42rem`) is exposed as a `max-w-content` utility through Tailwind's `--container-content` theme key, and the article, breadcrumb, mobile table of contents, page feedback, pagination, and last-updated line now use it instead of hardcoding `42rem`. Override `--blume-content-width` to re-measure the whole column at once; the default is unchanged.

--- a/.changeset/themeable-content-width.md
+++ b/.changeset/themeable-content-width.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Add a themeable content-column width. A new `--blume-content-width` token (default `42rem`) is exposed as a `max-w-content` utility through Tailwind's `--container-content` theme key, and the article, breadcrumb, mobile table of contents, page feedback, pagination, and last-updated line now use it instead of hardcoding `42rem`. Override `--blume-content-width` to re-measure the whole column at once; the default is unchanged.

--- a/packages/blume/src/components/layout/Breadcrumbs.astro
+++ b/packages/blume/src/components/layout/Breadcrumbs.astro
@@ -31,7 +31,7 @@ const eyebrowCrumb = crumbs.length > 1 ? crumbs[crumbs.length - 2] : null;
       aria-label={n.breadcrumb}
       class:list={[
         "mb-2 text-muted-foreground text-sm",
-        wide ? "max-w-none" : "mx-auto max-w-[42rem]",
+        wide ? "max-w-none" : "mx-auto max-w-content",
       ]}
     >
       {eyebrowCrumb.route ? (

--- a/packages/blume/src/components/layout/PageFeedback.astro
+++ b/packages/blume/src/components/layout/PageFeedback.astro
@@ -20,7 +20,7 @@ const buttonClass =
 
 <section
   aria-label={f.question}
-  class="mx-auto mt-12 flex max-w-[42rem] items-center justify-between gap-4 border-border border-t pt-6"
+  class="mx-auto mt-12 flex max-w-content items-center justify-between gap-4 border-border border-t pt-6"
   data-blume-page-feedback
 >
   <p class="text-muted-foreground text-sm">{f.question}</p>

--- a/packages/blume/src/components/layout/Pagination.astro
+++ b/packages/blume/src/components/layout/Pagination.astro
@@ -26,7 +26,7 @@ const s = { ...EN_UI.page, ...strings };
   (prev || next) && (
     <nav
       aria-label={s.pagination}
-      class="mx-auto mt-12 flex max-w-[42rem] justify-between gap-4 border-border border-t pt-6 max-md:flex-col"
+      class="mx-auto mt-12 flex max-w-content justify-between gap-4 border-border border-t pt-6 max-md:flex-col"
     >
       {prev ? (
         <a

--- a/packages/blume/src/components/layout/RootLayout.astro
+++ b/packages/blume/src/components/layout/RootLayout.astro
@@ -261,7 +261,7 @@ if (isBare) {
 } else if (isApiOperation) {
   gridClass = "lg:grid-cols-[17.5rem_minmax(0,1fr)]";
 }
-let articleClass = "prose mx-auto max-w-[42rem]";
+let articleClass = "prose mx-auto max-w-content";
 if (isBare) {
   articleClass = "prose mx-auto max-w-[54rem]";
 } else if (isApiOperation) {
@@ -592,7 +592,7 @@ const bannerKey = banner?.dismissible ? banner.key : null;
                 route={page.route}
               />
               {formattedLastModified && (
-                <p class="mx-auto mt-10 max-w-[42rem] text-muted-foreground text-sm">
+                <p class="mx-auto mt-10 max-w-content text-muted-foreground text-sm">
                   {strings.page.lastUpdated} {formattedLastModified}
                 </p>
               )}

--- a/packages/blume/src/components/layout/TableOfContents.astro
+++ b/packages/blume/src/components/layout/TableOfContents.astro
@@ -19,7 +19,7 @@ const { headings, title, variant } = Astro.props;
 
 {
   headings.length > 0 && variant === "mobile" && (
-    <details class="group mx-auto mb-6 max-w-[42rem] rounded-blume border border-border xl:hidden">
+    <details class="group mx-auto mb-6 max-w-content rounded-blume border border-border xl:hidden">
       <summary class="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 font-medium text-foreground text-sm [&::-webkit-details-marker]:hidden">
         <span>{title}</span>
         <Icon

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -55,6 +55,10 @@ const TOKEN_DEFAULTS = `:root {
   --blume-code-word-border: oklch(0.55 0.16 255 / 0.5);
   --blume-radius: 0.75rem;
 
+  /* Max width of the prose content column (article, breadcrumb, TOC, feedback,
+     pagination, last-updated). Override to re-measure the whole column at once. */
+  --blume-content-width: 42rem;
+
   /*
    * Font tokens resolve through optional src variables that Astro's Fonts API
    * populates (via theme.fonts). When unset they fall back to the system
@@ -128,6 +132,7 @@ const THEME_MAPPING = `@theme inline {
   --color-action-foreground: var(--blume-action-foreground);
   --color-code: var(--blume-code-background);
   --radius-blume: var(--blume-radius);
+  --container-content: var(--blume-content-width);
   --font-sans: var(--blume-font-body);
   --font-mono: var(--blume-font-mono);
   --font-display: var(--blume-font-display);


### PR DESCRIPTION
Draft / proposal — happy to adjust naming or approach.

The prose content column's max width is currently hardcoded as `max-w-[42rem]` in six places: the article, breadcrumb, mobile table of contents, page feedback, pagination, and the "last updated" line. Widening or narrowing the column means editing all six in lockstep, and a consumer can't retheme it at all.

This lifts that measure to a themeable token, following the same shape Blume already uses for radius (`--blume-radius` → `@theme --radius-blume` → `rounded-blume`):

- New `--blume-content-width: 42rem` base token.
- Mapped through `@theme inline { --container-content: var(--blume-content-width) }`, which Tailwind turns into a `max-w-content` utility.
- All six call sites use `max-w-content`.

The default is unchanged (`42rem`), so nothing moves out of the box. A consumer can now re-measure the whole column with a single override:

```css
:root { --blume-content-width: 48rem; }
```

**Verified** by building `apps/docs`: the generated CSS contains `--blume-content-width: 42rem` and `.max-w-content { max-width: var(--blume-content-width) }`, with no remaining hardcoded `max-width: 42rem`. A `minor` changeset is included.

A couple of open questions for you:
- Naming — `max-w-content` / `--blume-content-width` felt the most descriptive, but happy to rename (`--container-prose`, etc.).
- Whether you'd eventually want this surfaced through config (e.g. `theme.contentWidth`) the way `theme.radius` is — glad to follow up with that if so.

Thanks for Blume!