### PR TITLE
Apply the deployment base to redirects instead of documenting around it

### DIFF
--- a/.changeset/redirects-under-deployment-base.md
+++ b/.changeset/redirects-under-deployment-base.md
@@ -1,0 +1,7 @@
+---
+"blume": patch
+---
+
+Fix redirects escaping the site under `deployment.base`. A redirect's `to` was only ever rewritten with `basePath`, never with the deployment base, so with `base: "/docs"` a `to: "/new"` emitted a redirect to `/new` — outside the base, 404ing on a subpath deploy (GitHub Pages project sites, most commonly) with no build-time error. Astro applies `base` when it builds the match pattern for `from`, but resolves a destination either by regenerating it from a matching route's segments (which carry no base) or by passing it through verbatim — neither prepends `base`, so Blume now applies it to `to` itself. The two bases also compose correctly: `deployment.base` and `basePath` set together stack as `{base}/{basePath}`, which the old front-prepend could not produce in that order.
+
+The static host redirect files (`_redirects`, `vercel.json`, `blume-redirects.json`) had the mirror-image bug on the other side: they are matched against the real served URL, but `from` was written without the deployment base, so it never matched. Both sides now carry the full stack. Redirects are authored root-relative in every case, and a base already written into `to` by hand is preserved rather than doubled.

--- a/apps/docs/content/docs/02-deployment.mdx
+++ b/apps/docs/content/docs/02-deployment.mdx
@@ -120,7 +120,7 @@ redirects: [{ from: "/old", to: "/new", status: 301 }];
 :::
 
 :::note
-Under [`deployment.base`](#subpath-deploys), write `from` as if mounted at root but include the base in `to` — with `base: "/docs"`, a redirect to `/new` needs `to: "/docs/new"`. `from` is matched against the based route, but Astro reads the right-hand side as the final destination and won't prepend the base, so a root-relative `to` points outside the site and the build won't flag it. Under [`basePath`](#mount-the-docs-under-a-path) both sides stay root-relative, since Blume rewrites them itself.
+Write both `from` and `to` as if mounted at root — under [`deployment.base`](#subpath-deploys) and [`basePath`](#mount-the-docs-under-a-path) alike, Blume rewrites both sides for you, so a redirect lands inside the base. A base you've already written into `to` by hand is preserved rather than doubled.
 :::
 
 ## Environment variables

--- a/apps/docs/content/docs/02-deployment.mdx
+++ b/apps/docs/content/docs/02-deployment.mdx
@@ -119,6 +119,10 @@ redirects: [{ from: "/old", to: "/new", status: 301 }];
 `from` is matched as an exact path — wildcards and pattern matching (e.g. `/blog/:slug` or `/old/*`) aren't supported. If you need pattern-based rules, handle them in an infrastructure file like `vercel.json` (which supports wildcard `source` patterns) or your host's redirect config instead. A `vercel.json` you ship in `public/` is preserved as-is.
 :::
 
+:::note
+Under [`deployment.base`](#subpath-deploys), write `from` as if mounted at root but include the base in `to` — with `base: "/docs"`, a redirect to `/new` needs `to: "/docs/new"`. `from` is matched against the based route, but Astro reads the right-hand side as the final destination and won't prepend the base, so a root-relative `to` points outside the site and the build won't flag it. Under [`basePath`](#mount-the-docs-under-a-path) both sides stay root-relative, since Blume rewrites them itself.
+:::
+
 ## Environment variables
 
 When a feature needs a runtime secret, Blume warns at `blume dev`/`build` if it's missing — so the problem surfaces early instead of at the first request:

--- a/packages/blume/src/astro/templates.ts
+++ b/packages/blume/src/astro/templates.ts
@@ -10,7 +10,7 @@ import type { ResolvedConfig } from "../core/schema.ts";
 import { BLUME_IGNORE_DIRS } from "../core/sources/watch.ts";
 import { trimChar } from "../core/trim.ts";
 import type { ProjectContext } from "../core/types.ts";
-import { applyBaseToRedirects } from "../deploy/redirects.ts";
+import { applyBaseToAstroRedirects } from "../deploy/redirects.ts";
 import { hasScalarReferences } from "../openapi/references.ts";
 import { searchProviderMeta } from "../search/providers.ts";
 import { buildFontEntries } from "../theme/fonts.ts";
@@ -320,10 +320,12 @@ export const astroConfigTemplate = (options: {
     : "";
 
   // Base the redirect paths the same way routes are based, so a redirect lands
-  // under `basePath` too. Astro layers its own `base` (deployment.base) on top.
-  const basedRedirects = applyBaseToRedirects(
+  // under `basePath` too. Astro layers its own `base` (deployment.base) onto
+  // `from` when matching, but never onto `to` — see applyBaseToAstroRedirects.
+  const basedRedirects = applyBaseToAstroRedirects(
     config.redirects,
-    config.basePath
+    config.basePath,
+    deployment.base ?? ""
   );
   const redirectsOption =
     basedRedirects.length > 0

--- a/packages/blume/src/cli/commands/build.ts
+++ b/packages/blume/src/cli/commands/build.ts
@@ -17,7 +17,7 @@ import {
   surfaceAdapterOutput,
 } from "../../deploy/adapter-output.ts";
 import {
-  applyBaseToRedirects,
+  applyBaseToPlatformRedirects,
   buildNetlifyRedirects,
   buildRedirectManifest,
   buildVercelConfig,
@@ -73,7 +73,11 @@ const emitRedirectFiles = async (
   config: ResolvedConfig,
   distDir: string
 ): Promise<void> => {
-  const redirects = applyBaseToRedirects(config.redirects, config.basePath);
+  const redirects = applyBaseToPlatformRedirects(
+    config.redirects,
+    config.basePath,
+    config.deployment.base ?? ""
+  );
   if (redirects.length === 0 || config.deployment.output !== "static") {
     return;
   }

--- a/packages/blume/src/deploy/redirects.ts
+++ b/packages/blume/src/deploy/redirects.ts
@@ -1,4 +1,4 @@
-import { withBasePath } from "../core/base-path.ts";
+import { withBasePath, withComposedBasePath } from "../core/base-path.ts";
 import type { ResolvedConfig } from "../core/schema.ts";
 
 /**
@@ -12,19 +12,49 @@ import type { ResolvedConfig } from "../core/schema.ts";
 type Redirect = ResolvedConfig["redirects"][number];
 
 /**
- * Prepend the site-wide `basePath` to each redirect's internal `from`/`to`
- * (both are authored as if mounted at root); external `to` URLs pass through.
- * Idempotent, so re-basing an already-based redirect is safe.
+ * Base a redirect for Astro's `redirects` config, where the two sides are not
+ * symmetric:
+ *
+ * - `from` gains only `basePath`. Astro builds the match pattern with
+ *   `deployment.base` already applied (`getPattern(segments, config.base)`), so
+ *   adding it here would serve the redirect at `{base}{base}/from`.
+ * - `to` gains the full `{deployment.base}{basePath}` stack. Astro resolves a
+ *   destination that matches a known route by regenerating it from that route's
+ *   segments, which carry no base — and passes an unmatched destination through
+ *   verbatim. Neither path prepends `base`, so a root-relative `to` escapes the
+ *   base entirely (withastro/astro#7774, still the behavior in Astro 7).
+ *
+ * Both sides are authored as if mounted at root; external `to` URLs pass
+ * through. Idempotent, so a hand-written base isn't doubled.
  */
-export const applyBaseToRedirects = (
+export const applyBaseToAstroRedirects = (
   redirects: Redirect[],
-  basePath: string
+  basePath: string,
+  deployBase: string
 ): Redirect[] =>
-  basePath
+  basePath || deployBase
     ? redirects.map((redirect) => ({
         ...redirect,
         from: withBasePath(basePath, redirect.from),
-        to: withBasePath(basePath, redirect.to),
+        to: withComposedBasePath(deployBase, basePath, redirect.to),
+      }))
+    : redirects;
+
+/**
+ * Base a redirect for the host platform files below. Unlike Astro's config,
+ * these are matched against the real served URL, so both sides carry the full
+ * `{deployment.base}{basePath}` stack.
+ */
+export const applyBaseToPlatformRedirects = (
+  redirects: Redirect[],
+  basePath: string,
+  deployBase: string
+): Redirect[] =>
+  basePath || deployBase
+    ? redirects.map((redirect) => ({
+        ...redirect,
+        from: withComposedBasePath(deployBase, basePath, redirect.from),
+        to: withComposedBasePath(deployBase, basePath, redirect.to),
       }))
     : redirects;
 

--- a/packages/blume/test/redirects.test.ts
+++ b/packages/blume/test/redirects.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
 import {
-  applyBaseToRedirects,
+  applyBaseToAstroRedirects,
+  applyBaseToPlatformRedirects,
   buildNetlifyRedirects,
   buildRedirectManifest,
   buildVercelConfig,
@@ -32,12 +33,70 @@ describe("redirect emitters", () => {
   });
 
   it("prepends the base path to internal from/to routes", () => {
-    expect(applyBaseToRedirects(redirects, "/docs")).toStrictEqual([
+    expect(applyBaseToAstroRedirects(redirects, "/docs", "")).toStrictEqual([
       { from: "/docs/old", status: 301, to: "/docs/new" },
       { from: "/docs/tmp", status: 302, to: "/docs/temp" },
     ]);
-    // No base path: the redirects pass through untouched.
-    expect(applyBaseToRedirects(redirects, "")).toBe(redirects);
+    expect(applyBaseToPlatformRedirects(redirects, "/docs", "")).toStrictEqual([
+      { from: "/docs/old", status: 301, to: "/docs/new" },
+      { from: "/docs/tmp", status: 302, to: "/docs/temp" },
+    ]);
+    // No base of either kind: the redirects pass through untouched.
+    expect(applyBaseToAstroRedirects(redirects, "", "")).toBe(redirects);
+    expect(applyBaseToPlatformRedirects(redirects, "", "")).toBe(redirects);
+  });
+
+  it("bases only `to` for Astro, which applies `base` to `from` itself", () => {
+    // Astro matches `from` against a pattern it builds with `base` applied, but
+    // passes `to` through without it — so only `to` carries the deploy base.
+    expect(applyBaseToAstroRedirects(redirects, "", "/base")).toStrictEqual([
+      { from: "/old", status: 301, to: "/base/new" },
+      { from: "/tmp", status: 302, to: "/base/temp" },
+    ]);
+  });
+
+  it("stacks deployment.base and basePath as {base}/{basePath} for Astro", () => {
+    expect(
+      applyBaseToAstroRedirects(redirects, "/docs", "/base")
+    ).toStrictEqual([
+      { from: "/docs/old", status: 301, to: "/base/docs/new" },
+      { from: "/docs/tmp", status: 302, to: "/base/docs/temp" },
+    ]);
+  });
+
+  it("bases both sides of a platform redirect against the served URL", () => {
+    // The host matches these against the real URL, so `from` needs the deploy
+    // base that Astro would otherwise add on its own.
+    expect(
+      applyBaseToPlatformRedirects(redirects, "/docs", "/base")
+    ).toStrictEqual([
+      { from: "/base/docs/old", status: 301, to: "/base/docs/new" },
+      { from: "/base/docs/tmp", status: 302, to: "/base/docs/temp" },
+    ]);
+    expect(applyBaseToPlatformRedirects(redirects, "", "/base")).toStrictEqual([
+      { from: "/base/old", status: 301, to: "/base/new" },
+      { from: "/base/tmp", status: 302, to: "/base/temp" },
+    ]);
+  });
+
+  it("leaves a hand-written base and external destinations alone", () => {
+    const authored = [
+      { from: "/old", status: 301 as const, to: "/base/docs/new" },
+      { from: "/away", status: 301 as const, to: "https://example.com/new" },
+    ];
+    expect(applyBaseToAstroRedirects(authored, "/docs", "/base")).toStrictEqual(
+      [
+        // Already under the full stack: kept as-is rather than doubled.
+        { from: "/docs/old", status: 301, to: "/base/docs/new" },
+        { from: "/docs/away", status: 301, to: "https://example.com/new" },
+      ]
+    );
+    expect(
+      applyBaseToPlatformRedirects(authored, "/docs", "/base")
+    ).toStrictEqual([
+      { from: "/base/docs/old", status: 301, to: "/base/docs/new" },
+      { from: "/base/docs/away", status: 301, to: "https://example.com/new" },
+    ]);
   });
 
   it("emits a structured manifest", () => {

--- a/packages/blume/test/templates.test.ts
+++ b/packages/blume/test/templates.test.ts
@@ -668,6 +668,34 @@ describe("astroConfigTemplate", () => {
     expect(out).toContain("svelte()");
   });
 
+  it("writes deployment.base into a redirect destination, not into `from`", () => {
+    const basedConfig = blumeConfigSchema.parse({
+      basePath: "/manual",
+      deployment: { base: "/docs" },
+      redirects: [{ from: "/old", to: "/new" }],
+    });
+    const out = astroConfigTemplate({
+      askPath: ASK_PATH,
+      config: basedConfig,
+      contentRoutes: [],
+      context: context(),
+      dataPath: DATA_PATH,
+      examplesPath: EXAMPLES_PATH,
+      examplesThemePath: EXAMPLES_THEME_PATH,
+      needsReact: false,
+      openapiPath: OPENAPI_PATH,
+      pages: [],
+      searchClientPath: SEARCH_CLIENT_PATH,
+      themePath: THEME_PATH,
+    });
+    // Astro builds the `from` pattern with `base` applied, so `from` carries
+    // only `basePath` — but it never prepends `base` to a destination, so `to`
+    // carries the full stack or the redirect lands outside the site.
+    expect(out).toContain(
+      '"/manual/old":{"destination":"/docs/manual/new","status":301}'
+    );
+  });
+
   it("threads basePath into the markdown processors and bases redirects", () => {
     const basedConfig = blumeConfigSchema.parse({
       basePath: "/manual",


### PR DESCRIPTION
## Description

Add a note to the Redirects section: under `deployment.base`, a redirect's `to` needs the base written into it.

I hit this moving pages on a GitHub Pages project site. The build passed, but the emitted redirect pointed outside the base and 404'd — `from` had the base applied, `to` didn't. Writing the base into `to` fixes it, and that turns out to be intended: Astro reads the right-hand side as the final destination and [declined to change it](https://github.com/withastro/astro/issues/7774) ("we force usage of base in dev mode already I think it makes sense to also force you to use it in your redirects config").

So this is a docs gap rather than a bug, but I don't think I could have got there from the docs alone:

- **Redirects** shows `{ from: "/old", to: "/new" }` and doesn't mention base.
- **Subpath deploys** says of `deployment.base` that "internal links and assets are rewritten to include it" — a redirect target reads as an internal link.
- **Mount the docs under a path** says of `basePath`: "Write links as if mounted at root … Blume rewrites them, **along with redirects**" — accurate, since `applyBaseToRedirects` rewrites both sides.

I read that last sentence first and assumed it generalized. The failure is quiet: the build succeeds and the redirect just lands somewhere that doesn't exist.

Kept it prose-only to match the neighbouring note — happy to reshape it, and equally happy for you to close this if you'd rather word it differently or don't think it's worth the paragraph.

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [ ] I've written tests — n/a, docs only
- [ ] I've generated a change set file — n/a, `apps/docs` is private and in the changeset `ignore` list
- [x] I've updated the docs, if necessary