### PR TITLE
Add search.popular for curated Cmd+K empty-state links

### DIFF
--- a/.changeset/search-popular-pages.md
+++ b/.changeset/search-popular-pages.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Add `search.popular` to curate the Cmd+K empty-state link list. When set, each `{ href, label }` entry replaces the default first-six sidebar pages — useful on multi-tab sites where sidebar order surfaces the wrong section. Each `href` is authored root-relative and picks up `basePath` automatically (external URLs pass through). Omit or leave empty to keep the sidebar fallback.
+Add `search.popular` to curate the Cmd+K empty-state link list. When set, each `{ href, label, icon? }` entry replaces the default first-six sidebar pages — useful on multi-tab sites where sidebar order surfaces the wrong section. Each `href` is authored root-relative and picks up `basePath` automatically (external URLs pass through); `icon` takes a built-in icon name and defaults to a file glyph. Omit or leave empty to keep the sidebar fallback.

--- a/.changeset/search-popular-pages.md
+++ b/.changeset/search-popular-pages.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Add `search.popular` to curate the Cmd+K empty-state link list. When set, each `{ href, label }` entry replaces the default first-six sidebar pages — useful on multi-tab sites where sidebar order surfaces the wrong section. Omit or leave empty to keep the sidebar fallback.

--- a/.changeset/search-popular-pages.md
+++ b/.changeset/search-popular-pages.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Add `search.popular` to curate the Cmd+K empty-state link list. When set, each `{ href, label }` entry replaces the default first-six sidebar pages — useful on multi-tab sites where sidebar order surfaces the wrong section. Omit or leave empty to keep the sidebar fallback.
+Add `search.popular` to curate the Cmd+K empty-state link list. When set, each `{ href, label }` entry replaces the default first-six sidebar pages — useful on multi-tab sites where sidebar order surfaces the wrong section. Each `href` is authored root-relative and picks up `basePath` automatically (external URLs pass through). Omit or leave empty to keep the sidebar fallback.

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -13,6 +13,22 @@ Open search with <Badge variant="accent">⌘K</Badge> (or `Ctrl K`), or press `/
 
 Queries match page **titles**, **descriptions**, and **body text**, with title matches ranked highest and descriptions above body.
 
+## Popular pages
+
+Before a reader types a query, the search dialog shows a **Popular** list. By default it is the first six sidebar pages — which on multi-tab sites often surfaces the wrong section. Pin the links you want instead:
+
+```ts blume.config.ts lineNumbers
+search: {
+  popular: [
+    { href: "/guides/getting-started", label: "Getting started" },
+    { href: "/guides/install", label: "Install" },
+    { href: "/concepts/overview", label: "Overview" },
+  ],
+},
+```
+
+Each entry takes an `href` (internal route or external URL) and a `label`. Omit `popular` or leave it empty to keep the sidebar fallback.
+
 ## What's indexed
 
 For every indexable page, Blume indexes its title, description, and body reduced to plain text — code blocks, images, and markup are stripped, so results stay relevant. The index is built from your source files, so it's identical in dev and production.

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -29,6 +29,15 @@ search: {
 
 Each entry takes an `href` (internal route or external URL) and a `label`. Omit `popular` or leave it empty to keep the sidebar fallback.
 
+Write `href` as if the site were mounted at the root — a `basePath` is applied for you, the same as `navigation.featured`. External URLs pass through untouched.
+
+<Callout type="warning">
+  A curated list is a single set of links shared by every language. On a site
+  with `i18n` configured, the sidebar fallback follows the reader's locale, but
+  `popular` entries point wherever their `href` says — so pin locale-prefixed
+  routes only if you want every reader sent to that one language.
+</Callout>
+
 ## What's indexed
 
 For every indexable page, Blume indexes its title, description, and body reduced to plain text — code blocks, images, and markup are stripped, so results stay relevant. The index is built from your source files, so it's identical in dev and production.

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -20,14 +20,16 @@ Before a reader types a query, the search dialog shows a **Popular** list. By de
 ```ts blume.config.ts lineNumbers
 search: {
   popular: [
-    { href: "/guides/getting-started", label: "Getting started" },
-    { href: "/guides/install", label: "Install" },
+    { href: "/guides/getting-started", icon: "rocket", label: "Getting started" },
+    { href: "/guides/install", icon: "download", label: "Install" },
     { href: "/concepts/overview", label: "Overview" },
   ],
 },
 ```
 
-Each entry takes an `href` (internal route or external URL) and a `label`. Omit `popular` or leave it empty to keep the sidebar fallback.
+Each entry takes an `href` (internal route or external URL) and a `label`, plus an optional `icon` — a built-in icon name shown beside the label, defaulting to a file glyph. Omit `popular` or leave it empty to keep the sidebar fallback.
+
+Unlike icons elsewhere in Blume, `icon` here must be a built-in name: these rows render in a client island, so an image path or inline SVG isn't supported and falls back to the file glyph.
 
 Write `href` as if the site were mounted at the root — a `basePath` is applied for you, the same as `navigation.featured`. External URLs pass through untouched.
 

--- a/packages/blume/src/astro/generate.ts
+++ b/packages/blume/src/astro/generate.ts
@@ -29,7 +29,10 @@ import type {
 } from "../core/data.ts";
 import { EN_UI, resolveUIStrings } from "../core/i18n-ui.ts";
 import { resolveFallbackLocale } from "../core/i18n.ts";
-import { validateNavTargets } from "../core/nav-diagnostics.ts";
+import {
+  validateNavTargets,
+  validateSearchPopularIcons,
+} from "../core/nav-diagnostics.ts";
 import { packageRoot } from "../core/package-root.ts";
 import type { BlumeProject } from "../core/project-graph.ts";
 import type { ResolvedConfig } from "../core/schema.ts";
@@ -1511,12 +1514,18 @@ export const generateRuntime = async (
   if (hasGeneratedChangelog(project, pages)) {
     navTargetRoutes.add("/changelog");
   }
+  // Curated `search.popular` icons live outside the navigation model, so they
+  // miss `validateNavIcons` in the graph build — they're checked here too,
+  // where the search config is known. A typo otherwise just renders the
+  // default glyph.
   warnings.push(
-    ...validateNavTargets(project.graph.navigation, navTargetRoutes).map(
-      (diagnostic) =>
-        diagnostic.suggestion
-          ? `${diagnostic.message} ${diagnostic.suggestion}`
-          : diagnostic.message
+    ...[
+      ...validateNavTargets(project.graph.navigation, navTargetRoutes),
+      ...validateSearchPopularIcons(config.search.popular),
+    ].map((diagnostic) =>
+      diagnostic.suggestion
+        ? `${diagnostic.message} ${diagnostic.suggestion}`
+        : diagnostic.message
     )
   );
 

--- a/packages/blume/src/astro/generate.ts
+++ b/packages/blume/src/astro/generate.ts
@@ -43,6 +43,7 @@ import { buildReferenceFiles } from "../openapi/scalar.ts";
 import { isOpenApiSource } from "../openapi/source.ts";
 import { registry } from "../registry/registry.ts";
 import { buildSearchDocuments } from "../search/documents.ts";
+import { resolveSearchPopular } from "../search/popular.ts";
 import { searchProviderMeta, servesStaticIndex } from "../search/providers.ts";
 import {
   examplesEntryTemplate,
@@ -937,6 +938,10 @@ export const buildRuntimeData = (project: BlumeProject): string => {
       repoUrl,
       search: {
         enabled: config.search.provider !== "none",
+        popular:
+          config.search.popular.length > 0
+            ? resolveSearchPopular(config.search.popular)
+            : [],
         provider: config.search.provider,
       },
       site: config.deployment.site ?? null,

--- a/packages/blume/src/astro/generate.ts
+++ b/packages/blume/src/astro/generate.ts
@@ -938,10 +938,7 @@ export const buildRuntimeData = (project: BlumeProject): string => {
       repoUrl,
       search: {
         enabled: config.search.provider !== "none",
-        popular:
-          config.search.popular.length > 0
-            ? resolveSearchPopular(config.search.popular)
-            : [],
+        popular: resolveSearchPopular(config.search.popular, config.basePath),
         provider: config.search.provider,
       },
       site: config.deployment.site ?? null,

--- a/packages/blume/src/components/layout/Header.astro
+++ b/packages/blume/src/components/layout/Header.astro
@@ -182,6 +182,11 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
         askEnabled={askEnabled}
         locale={searchLocale}
         navigation={navigation}
+        popularPages={
+          data.config.search.popular.length > 0
+            ? data.config.search.popular
+            : undefined
+        }
         strings={searchStrings}
       />
     )

--- a/packages/blume/src/components/layout/Header.astro
+++ b/packages/blume/src/components/layout/Header.astro
@@ -182,11 +182,7 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
         askEnabled={askEnabled}
         locale={searchLocale}
         navigation={navigation}
-        popularPages={
-          data.config.search.popular.length > 0
-            ? data.config.search.popular
-            : undefined
-        }
+        popularPages={data.config.search.popular}
         strings={searchStrings}
       />
     )

--- a/packages/blume/src/components/layout/Search.astro
+++ b/packages/blume/src/components/layout/Search.astro
@@ -13,19 +13,27 @@ import { flattenPages } from "./nav-utils.ts";
 interface Props {
   askEnabled?: boolean;
   navigation?: Navigation;
+  /** Curated empty-state pages; falls back to the first sidebar pages when omitted. */
+  popularPages?: { label: string; route: string }[];
   strings?: UIStrings["search"];
   /** Active locale to filter results to; omitted disables locale filtering. */
   locale?: string;
 }
 
-const { askEnabled = false, navigation, strings, locale } = Astro.props;
+const { askEnabled = false, navigation, popularPages, strings, locale } =
+  Astro.props;
 // Merge over the English baseline per key (rather than `strings ?? …`) so a
 // partial — or empty `{}` — strings object still resolves every label to a
 // default, matching the pattern PageActions uses for its own dictionary.
 const s = { ...EN_UI.search, ...strings };
 
 // Pages shown in the empty state, before the user has typed anything.
-const popular = navigation ? flattenPages(navigation.sidebar).slice(0, 6) : [];
+const popular =
+  popularPages && popularPages.length > 0
+    ? popularPages
+    : navigation
+      ? flattenPages(navigation.sidebar).slice(0, 6)
+      : [];
 
 const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
 ---

--- a/packages/blume/src/components/layout/Search.astro
+++ b/packages/blume/src/components/layout/Search.astro
@@ -13,7 +13,7 @@ import { flattenPages } from "./nav-utils.ts";
 interface Props {
   askEnabled?: boolean;
   navigation?: Navigation;
-  /** Curated empty-state pages; falls back to the first sidebar pages when omitted. */
+  /** Curated empty-state pages; falls back to the first sidebar pages when empty or omitted. */
   popularPages?: { label: string; route: string }[];
   strings?: UIStrings["search"];
   /** Active locale to filter results to; omitted disables locale filtering. */

--- a/packages/blume/src/components/layout/Search.astro
+++ b/packages/blume/src/components/layout/Search.astro
@@ -2,6 +2,7 @@
 import { EN_UI } from "../../core/i18n-ui.ts";
 import type { UIStrings } from "../../core/i18n-ui.ts";
 import type { Navigation } from "../../core/types.ts";
+import { resolveIcon } from "../../theme/icons.ts";
 import Icon from "../Icon.astro";
 import { flattenPages } from "./nav-utils.ts";
 
@@ -14,7 +15,7 @@ interface Props {
   askEnabled?: boolean;
   navigation?: Navigation;
   /** Curated empty-state pages; falls back to the first sidebar pages when empty or omitted. */
-  popularPages?: { label: string; route: string }[];
+  popularPages?: { icon?: string; label: string; route: string }[];
   strings?: UIStrings["search"];
   /** Active locale to filter results to; omitted disables locale filtering. */
   locale?: string;
@@ -27,10 +28,26 @@ const { askEnabled = false, navigation, popularPages, strings, locale } =
 // default, matching the pattern PageActions uses for its own dictionary.
 const s = { ...EN_UI.search, ...strings };
 
-// Pages shown in the empty state, before the user has typed anything.
+// Icons resolve to inline SVG here (`theme/icons.ts` is a server-only module —
+// far too large to ship to the browser), so the island gets ready-to-render
+// markup rather than a name it can't resolve. Same approach as AskAI.astro.
+// A name outside the set falls through to the island's own file glyph.
+const iconSvg = (name: string | undefined): string | undefined => {
+  const resolved = name ? resolveIcon(name) : null;
+  return resolved
+    ? `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="${resolved.viewBox}" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${resolved.body}</svg>`
+    : undefined;
+};
+
+// Pages shown in the empty state, before the user has typed anything. Only
+// curated entries carry an icon; sidebar-derived rows keep the file glyph.
 const popular =
   popularPages && popularPages.length > 0
-    ? popularPages
+    ? popularPages.map((page) => ({
+        icon: iconSvg(page.icon),
+        label: page.label,
+        route: page.route,
+      }))
     : navigation
       ? flattenPages(navigation.sidebar).slice(0, 6)
       : [];
@@ -174,6 +191,8 @@ const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
     }
 
     interface PopularPage {
+      /** Pre-resolved inline SVG from the server; absent falls back to `file`. */
+      icon?: string;
       label: string;
       route: string;
     }
@@ -509,7 +528,7 @@ const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
         if (this.popular.length > 0) {
           const group = this.addGroup(this.popularMsg);
           for (const page of this.popular) {
-            const item = this.createLinkRow(page.route, page.label);
+            const item = this.createLinkRow(page.route, page.label, page.icon);
             group.appendChild(item.el);
             this.selectables.push(item);
           }
@@ -598,13 +617,15 @@ const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
         return item;
       }
 
-      createLinkRow(url: string, label: string): Selectable {
+      createLinkRow(url: string, label: string, icon?: string): Selectable {
         const el = document.createElement("a");
         const href = prefixBase(import.meta.env.BASE_URL, url);
         el.href = href;
         el.className = ROW_CLASS;
+        // `icon` is server-resolved markup from the bundled icon set, not
+        // author HTML — the label still goes through `escapeHtml`.
         el.innerHTML = `
-          <span class="mt-0.5 shrink-0 text-muted-foreground">${svg("file")}</span>
+          <span class="mt-0.5 shrink-0 text-muted-foreground">${icon ?? svg("file")}</span>
           <span class="flex-1">
             <span class="block truncate font-normal text-foreground text-sm">${escapeHtml(label)}</span>
           </span>`;

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -457,6 +457,8 @@ export interface MixedbreadSearch {
 export interface SearchPopularLink {
   /** Internal route or external URL. */
   href: string;
+  /** Built-in icon name shown beside the label; defaults to the file glyph. */
+  icon?: string;
   /** Link label shown in the dialog. */
   label: string;
 }

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -453,6 +453,14 @@ export interface MixedbreadSearch {
   storeId: string;
 }
 
+/** A curated link for the search dialog empty state. */
+export interface SearchPopularLink {
+  /** Internal route or external URL. */
+  href: string;
+  /** Link label shown in the dialog. */
+  label: string;
+}
+
 /**
  * Search backend. The default `orama` builds a local index at build time (and
  * runs in dev); hosted providers need their credential block below. `none`
@@ -470,6 +478,11 @@ export interface SearchConfig {
   mixedbread?: MixedbreadSearch;
   /** Orama Cloud credentials (required when `provider` is `orama-cloud`). */
   oramaCloud?: OramaCloudSearch;
+  /**
+   * Curated links for the Cmd+K empty state. When omitted or empty, the first
+   * sidebar pages are shown instead.
+   */
+  popular?: SearchPopularLink[];
   /** Which backend powers search. Defaults to `orama`. */
   provider?: SearchProvider;
   /** Typesense credentials (required when `provider` is `typesense`). */

--- a/packages/blume/src/core/data.ts
+++ b/packages/blume/src/core/data.ts
@@ -123,7 +123,7 @@ export interface BlumeDataConfig {
   search: {
     enabled: boolean;
     /** Resolved empty-state links; empty when unset (Search falls back to sidebar). */
-    popular: { label: string; route: string }[];
+    popular: { icon?: string; label: string; route: string }[];
     provider: SearchProvider;
   };
   /** Deployment site URL, or `null` when none is configured/detected. */

--- a/packages/blume/src/core/data.ts
+++ b/packages/blume/src/core/data.ts
@@ -120,7 +120,12 @@ export interface BlumeDataConfig {
   };
   /** Repository URL for header/edit links, or `null`. */
   repoUrl: string | null;
-  search: { enabled: boolean; provider: SearchProvider };
+  search: {
+    enabled: boolean;
+    /** Resolved empty-state links; empty when unset (Search falls back to sidebar). */
+    popular: { label: string; route: string }[];
+    provider: SearchProvider;
+  };
   /** Deployment site URL, or `null` when none is configured/detected. */
   site: string | null;
   structuredData: boolean;

--- a/packages/blume/src/core/nav-diagnostics.ts
+++ b/packages/blume/src/core/nav-diagnostics.ts
@@ -55,10 +55,13 @@ const collectIcons = (
 };
 
 /** Warn about icon names that aren't in Blume's set (skipping image/SVG icons). */
-export const validateNavIcons = (navigation: Navigation): Diagnostic[] => {
+const unknownIconDiagnostics = (
+  icons: { icon: string; where: string }[],
+  suggestion: string
+): Diagnostic[] => {
   const seen = new Set<string>();
   const diagnostics: Diagnostic[] = [];
-  for (const { icon, where } of collectIcons(navigation)) {
+  for (const { icon, where } of icons) {
     if (isAssetIcon(icon) || hasIcon(icon) || seen.has(icon)) {
       continue;
     }
@@ -67,12 +70,36 @@ export const validateNavIcons = (navigation: Navigation): Diagnostic[] => {
       code: "BLUME_UNKNOWN_ICON",
       message: `Unknown icon "${icon}" (${where}) — it isn't in Blume's icon set.`,
       severity: "warning",
-      suggestion:
-        "Use a built-in icon name, an image path/URL, or inline SVG markup.",
+      suggestion,
     });
   }
   return diagnostics;
 };
+
+/** Warn about icon names that aren't in Blume's set (skipping image/SVG icons). */
+export const validateNavIcons = (navigation: Navigation): Diagnostic[] =>
+  unknownIconDiagnostics(
+    collectIcons(navigation),
+    "Use a built-in icon name, an image path/URL, or inline SVG markup."
+  );
+
+/**
+ * Warn about unknown icons on curated `search.popular` links. Separate from
+ * {@link validateNavIcons} because these live under `search`, not the built
+ * navigation — and unlike nav icons they resolve in a *client* island, so only
+ * set names work (an image/SVG icon quietly falls back to the file glyph).
+ */
+export const validateSearchPopularIcons = (
+  popular: { icon?: string; label: string }[]
+): Diagnostic[] =>
+  unknownIconDiagnostics(
+    popular.flatMap((link) =>
+      link.icon
+        ? [{ icon: link.icon, where: `popular link "${link.label}"` }]
+        : []
+    ),
+    "Use a built-in icon name."
+  );
 
 /** Whether an internal path resolves to a page or a section that has pages. */
 const resolvesToPages = (routes: Set<string>, path: string): boolean =>

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -516,6 +516,12 @@ const PROVIDER_CONFIG_KEY = {
   typesense: "typesense",
 } as const;
 
+/** Curated link for the search dialog empty state (internal route or external URL). */
+const searchPopularLinkSchema = z.strictObject({
+  href: z.string(),
+  label: z.string(),
+});
+
 const searchConfigSchema = z
   .strictObject({
     algolia: algoliaSearchSchema.optional(),
@@ -526,6 +532,8 @@ const searchConfigSchema = z
       .default({}),
     mixedbread: mixedbreadSearchSchema.optional(),
     oramaCloud: oramaCloudSearchSchema.optional(),
+    /** Curated links for the Cmd+K empty state; defaults to the first sidebar pages. */
+    popular: z.array(searchPopularLinkSchema).default([]),
     provider: z.enum(searchProviders).default("orama"),
     typesense: typesenseSearchSchema.optional(),
   })

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -519,6 +519,7 @@ const PROVIDER_CONFIG_KEY = {
 /** Curated link for the search dialog empty state (internal route or external URL). */
 const searchPopularLinkSchema = z.strictObject({
   href: z.string(),
+  icon: iconName.optional(),
   label: z.string(),
 });
 

--- a/packages/blume/src/search/popular.ts
+++ b/packages/blume/src/search/popular.ts
@@ -1,0 +1,18 @@
+/** A resolved search empty-state link passed to the Search dialog. */
+export interface SearchPopularPage {
+  label: string;
+  route: string;
+}
+
+/**
+ * Map configured `search.popular` entries to `{ route, label }` for Search.
+ * Routes stay base-less — `createLinkRow` applies `prefixBase` at click time,
+ * same as sidebar-derived popular pages.
+ */
+export const resolveSearchPopular = (
+  popular: { href: string; label: string }[]
+): SearchPopularPage[] =>
+  popular.map(({ href, label }) => ({
+    label,
+    route: href,
+  }));

--- a/packages/blume/src/search/popular.ts
+++ b/packages/blume/src/search/popular.ts
@@ -2,6 +2,8 @@ import { withBasePath } from "../core/base-path.ts";
 
 /** A resolved search empty-state link passed to the Search dialog. */
 export interface SearchPopularPage {
+  /** Built-in icon name; `Search.astro` resolves it to markup at render time. */
+  icon?: string;
   label: string;
   route: string;
 }
@@ -16,12 +18,16 @@ export interface SearchPopularPage {
  *
  * `deployment.base` is deliberately *not* applied: routes stay deploy-base-less
  * so `createLinkRow` can prefix it at click time, same as sidebar-derived pages.
+ *
+ * `icon` stays a name here (like `navigation.featured`): the icon set is a
+ * server-only module, so `Search.astro` resolves it to inline SVG at render.
  */
 export const resolveSearchPopular = (
-  popular: { href: string; label: string }[],
+  popular: { href: string; icon?: string; label: string }[],
   basePath: string
 ): SearchPopularPage[] =>
-  popular.map(({ href, label }) => ({
+  popular.map(({ href, icon, label }) => ({
+    ...(icon ? { icon } : {}),
     label,
     route: withBasePath(basePath, href),
   }));

--- a/packages/blume/src/search/popular.ts
+++ b/packages/blume/src/search/popular.ts
@@ -1,3 +1,5 @@
+import { withBasePath } from "../core/base-path.ts";
+
 /** A resolved search empty-state link passed to the Search dialog. */
 export interface SearchPopularPage {
   label: string;
@@ -6,13 +8,20 @@ export interface SearchPopularPage {
 
 /**
  * Map configured `search.popular` entries to `{ route, label }` for Search.
- * Routes stay base-less — `createLinkRow` applies `prefixBase` at click time,
- * same as sidebar-derived popular pages.
+ *
+ * Curated hrefs are authored as if mounted at root, so `basePath` is applied
+ * here — matching `navigation.featured` and tab paths, and agreeing with the
+ * sidebar fallback these entries replace (whose routes are already based via
+ * `page.route`). `withBasePath` is idempotent and skips external URLs.
+ *
+ * `deployment.base` is deliberately *not* applied: routes stay deploy-base-less
+ * so `createLinkRow` can prefix it at click time, same as sidebar-derived pages.
  */
 export const resolveSearchPopular = (
-  popular: { href: string; label: string }[]
+  popular: { href: string; label: string }[],
+  basePath: string
 ): SearchPopularPage[] =>
   popular.map(({ href, label }) => ({
     label,
-    route: href,
+    route: withBasePath(basePath, href),
   }));

--- a/packages/blume/test/generate.test.ts
+++ b/packages/blume/test/generate.test.ts
@@ -223,7 +223,7 @@ describe("buildRuntimeData", () => {
         "blume.config.ts": `export default {
   search: {
     popular: [
-      { href: "/guides/start", label: "Start" },
+      { href: "/guides/start", icon: "rocket", label: "Start" },
       { href: "https://example.com", label: "Blog" },
     ],
   },
@@ -234,7 +234,7 @@ describe("buildRuntimeData", () => {
     );
     const data = JSON.parse(buildRuntimeData(project));
     expect(data.config.search.popular).toStrictEqual([
-      { label: "Start", route: "/guides/start" },
+      { icon: "rocket", label: "Start", route: "/guides/start" },
       { label: "Blog", route: "https://example.com" },
     ]);
   });

--- a/packages/blume/test/generate.test.ts
+++ b/packages/blume/test/generate.test.ts
@@ -206,6 +206,7 @@ describe("buildRuntimeData", () => {
     expect(data.config.mcp).toBeNull();
     expect(data.config.og.enabled).toBe(false);
     expect(data.config.search.provider).toBe("orama");
+    expect(data.config.search.popular).toStrictEqual([]);
     expect(data.config.favicon.href.startsWith("data:image/png")).toBe(true);
     expect(data.navigationByLocale).toEqual({});
     expect(data.uiByLocale).toEqual({});
@@ -214,6 +215,29 @@ describe("buildRuntimeData", () => {
       (route: { editUrl: string | null; path: string }) => route.path === "/"
     );
     expect(home.editUrl).toBeNull();
+  });
+
+  it("resolves search.popular into runtime data", async () => {
+    const project = await scanProject(
+      await writeProject({
+        "blume.config.ts": `export default {
+  basePath: "/docs",
+  search: {
+    popular: [
+      { href: "/guides/start", label: "Start" },
+      { href: "https://example.com", label: "Blog" },
+    ],
+  },
+};
+`,
+        "docs/index.md": "# Home\n",
+      })
+    );
+    const data = JSON.parse(buildRuntimeData(project));
+    expect(data.config.search.popular).toStrictEqual([
+      { label: "Start", route: "/guides/start" },
+      { label: "Blog", route: "https://example.com" },
+    ]);
   });
 
   it("resolves github edit urls, repo url, banner, logo, mcp and og", async () => {

--- a/packages/blume/test/generate.test.ts
+++ b/packages/blume/test/generate.test.ts
@@ -221,7 +221,6 @@ describe("buildRuntimeData", () => {
     const project = await scanProject(
       await writeProject({
         "blume.config.ts": `export default {
-  basePath: "/docs",
   search: {
     popular: [
       { href: "/guides/start", label: "Start" },
@@ -236,6 +235,34 @@ describe("buildRuntimeData", () => {
     const data = JSON.parse(buildRuntimeData(project));
     expect(data.config.search.popular).toStrictEqual([
       { label: "Start", route: "/guides/start" },
+      { label: "Blog", route: "https://example.com" },
+    ]);
+  });
+
+  it("bases search.popular routes under basePath", async () => {
+    const project = await scanProject(
+      await writeProject({
+        "blume.config.ts": `export default {
+  basePath: "/docs",
+  search: {
+    popular: [
+      { href: "/guides/start", label: "Start" },
+      { href: "/docs/guides/hand-written", label: "Hand written" },
+      { href: "https://example.com", label: "Blog" },
+    ],
+  },
+};
+`,
+        "docs/index.md": "# Home\n",
+      })
+    );
+    const data = JSON.parse(buildRuntimeData(project));
+    // Curated hrefs are authored root-relative, so they gain the base — the
+    // sidebar fallback's routes are already based. An author-written base is
+    // not doubled, and external URLs pass through.
+    expect(data.config.search.popular).toStrictEqual([
+      { label: "Start", route: "/docs/guides/start" },
+      { label: "Hand written", route: "/docs/guides/hand-written" },
       { label: "Blog", route: "https://example.com" },
     ]);
   });

--- a/packages/blume/test/nav-diagnostics.test.ts
+++ b/packages/blume/test/nav-diagnostics.test.ts
@@ -4,6 +4,7 @@ import {
   validateNavIcons,
   validateNavStructure,
   validateNavTargets,
+  validateSearchPopularIcons,
 } from "../src/core/nav-diagnostics.ts";
 import type { Navigation, PageRecord } from "../src/core/types.ts";
 
@@ -13,6 +14,27 @@ const nav = (over: Partial<Navigation> = {}): Navigation => ({
   sidebar: [],
   tabs: [],
   ...over,
+});
+
+describe("validateSearchPopularIcons", () => {
+  it("warns about an unknown icon name, naming the link", () => {
+    const result = validateSearchPopularIcons([
+      { icon: "not-a-real-icon", label: "Start" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.code).toBe("BLUME_UNKNOWN_ICON");
+    expect(result[0]?.message).toContain("not-a-real-icon");
+    expect(result[0]?.message).toContain('popular link "Start"');
+  });
+
+  it("accepts a known built-in icon and an entry with none", () => {
+    expect(
+      validateSearchPopularIcons([
+        { icon: "rocket", label: "Start" },
+        { label: "No icon" },
+      ])
+    ).toEqual([]);
+  });
 });
 
 describe("validateNavIcons", () => {

--- a/packages/blume/test/search-popular.test.ts
+++ b/packages/blume/test/search-popular.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { blumeConfigSchema } from "../src/core/schema.ts";
+import { resolveSearchPopular } from "../src/search/popular.ts";
+
+describe("search.popular config", () => {
+  it("defaults to an empty list", () => {
+    expect(blumeConfigSchema.parse({}).search.popular).toStrictEqual([]);
+  });
+
+  it("parses curated links", () => {
+    const config = blumeConfigSchema.parse({
+      search: {
+        popular: [
+          { href: "/guides/start", label: "Getting started" },
+          { href: "https://example.com", label: "Blog" },
+        ],
+      },
+    });
+    expect(config.search.popular).toStrictEqual([
+      { href: "/guides/start", label: "Getting started" },
+      { href: "https://example.com", label: "Blog" },
+    ]);
+  });
+
+  it("rejects entries missing href or label", () => {
+    expect(
+      blumeConfigSchema.safeParse({
+        search: { popular: [{ label: "No href" }] },
+      }).success
+    ).toBe(false);
+    expect(
+      blumeConfigSchema.safeParse({
+        search: { popular: [{ extra: true, href: "/x", label: "X" }] },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("resolveSearchPopular", () => {
+  it("keeps hrefs as routes (base applied at click time)", () => {
+    expect(
+      resolveSearchPopular([
+        { href: "/guides/start", label: "Start" },
+        { href: "https://example.com", label: "Blog" },
+      ])
+    ).toStrictEqual([
+      { label: "Start", route: "/guides/start" },
+      { label: "Blog", route: "https://example.com" },
+    ]);
+  });
+});

--- a/packages/blume/test/search-popular.test.ts
+++ b/packages/blume/test/search-popular.test.ts
@@ -23,6 +23,25 @@ describe("search.popular config", () => {
     ]);
   });
 
+  it("parses an optional icon", () => {
+    const config = blumeConfigSchema.parse({
+      search: {
+        popular: [{ href: "/guides/start", icon: "rocket", label: "Start" }],
+      },
+    });
+    expect(config.search.popular).toStrictEqual([
+      { href: "/guides/start", icon: "rocket", label: "Start" },
+    ]);
+  });
+
+  it("rejects an empty icon name", () => {
+    expect(
+      blumeConfigSchema.safeParse({
+        search: { popular: [{ href: "/x", icon: "", label: "X" }] },
+      }).success
+    ).toBe(false);
+  });
+
   it("rejects entries missing href or label", () => {
     expect(
       blumeConfigSchema.safeParse({
@@ -81,5 +100,22 @@ describe("resolveSearchPopular", () => {
         "/docs"
       )
     ).toStrictEqual([{ label: "Start", route: "/docs/guides/start" }]);
+  });
+
+  it("passes an icon name through, omitting the key when unset", () => {
+    // The name resolves to markup in `Search.astro` — the icon set is a
+    // server-only module the client island can't import.
+    expect(
+      resolveSearchPopular(
+        [
+          { href: "/guides/start", icon: "rocket", label: "Start" },
+          { href: "/guides/next", label: "Next" },
+        ],
+        ""
+      )
+    ).toStrictEqual([
+      { icon: "rocket", label: "Start", route: "/guides/start" },
+      { label: "Next", route: "/guides/next" },
+    ]);
   });
 });

--- a/packages/blume/test/search-popular.test.ts
+++ b/packages/blume/test/search-popular.test.ts
@@ -38,15 +38,48 @@ describe("search.popular config", () => {
 });
 
 describe("resolveSearchPopular", () => {
-  it("keeps hrefs as routes (base applied at click time)", () => {
+  // `deployment.base` is never applied here — `prefixBase` adds it in the Search
+  // island at click time, so a resolved route must stay deploy-base-less.
+  it("keeps hrefs as routes when no basePath is set", () => {
     expect(
-      resolveSearchPopular([
-        { href: "/guides/start", label: "Start" },
-        { href: "https://example.com", label: "Blog" },
-      ])
+      resolveSearchPopular(
+        [
+          { href: "/guides/start", label: "Start" },
+          { href: "https://example.com", label: "Blog" },
+        ],
+        ""
+      )
     ).toStrictEqual([
       { label: "Start", route: "/guides/start" },
       { label: "Blog", route: "https://example.com" },
     ]);
+  });
+
+  it("applies basePath to internal hrefs only", () => {
+    expect(
+      resolveSearchPopular(
+        [
+          { href: "/guides/start", label: "Start" },
+          { href: "/", label: "Home" },
+          { href: "https://example.com", label: "Blog" },
+          { href: "//cdn.example.com/x", label: "Protocol relative" },
+        ],
+        "/docs"
+      )
+    ).toStrictEqual([
+      { label: "Start", route: "/docs/guides/start" },
+      { label: "Home", route: "/docs" },
+      { label: "Blog", route: "https://example.com" },
+      { label: "Protocol relative", route: "//cdn.example.com/x" },
+    ]);
+  });
+
+  it("does not double-prefix a hand-written basePath", () => {
+    expect(
+      resolveSearchPopular(
+        [{ href: "/docs/guides/start", label: "Start" }],
+        "/docs"
+      )
+    ).toStrictEqual([{ label: "Start", route: "/docs/guides/start" }]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds optional `search.popular: { href, label }[]` so sites can pin the ⌘K empty-state list instead of taking the first six sidebar pages.
- Empty/omitted keeps the existing sidebar fallback.
- Routes stay base-less until click time (same as sidebar-derived pages), so `deployment.base` doesn't get applied twice.
- Docs + changeset + tests.

Fixes #73.

## Test plan

- [x] `bun test` coverage for schema + `resolveSearchPopular` + runtime data
- [x] Pre-commit typecheck / ultracite / full package tests
- [ ] Smoke: set `search.popular` under a non-`/` `deployment.base` and confirm links resolve once
- [ ] Smoke: omit `popular` and confirm sidebar first-six still shows