### PR TITLE
Render authentication requirements in the native OpenAPI reference

### DIFF
--- a/.changeset/openapi-authorization.md
+++ b/.changeset/openapi-authorization.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Render authentication requirements in the native OpenAPI reference. Operations that declare security requirements — their own `security`, or the document's root default — now show an **Authorization** section above their parameters: the credential's carrier (`Authorization` header, API-key header/query/cookie), a human label per scheme type (Bearer token, Basic auth, API key, OAuth2, OpenID Connect, Mutual TLS), the scheme's description, and OAuth scopes. Multiple requirement alternatives render as "or" groups (schemes within one requirement are required together), an empty `{}` requirement marks auth as optional, and `security: []` on an operation keeps it public with no section. The generated code samples now send a matching placeholder credential (e.g. `-H "Authorization: Bearer YOUR_TOKEN"`), with a spec-declared explicit header parameter still taking precedence, and a query-borne API key appended to the sample URL. Previously the renderer ignored `security` entirely, so authenticated endpoints were indistinguishable from public ones.

--- a/apps/docs/content/docs/advanced/api-reference.mdx
+++ b/apps/docs/content/docs/advanced/api-reference.mdx
@@ -78,6 +78,17 @@ openapi: {
 
 `spec` is shorthand for a single-entry `sources`, so you only reach for `sources` when you have more than one.
 
+## Authorization
+
+Operations that declare [security requirements](https://spec.openapis.org/oas/v3.1.0#security-requirement-object) render an **Authorization** section above their parameters, and the generated code samples send a placeholder credential (`Authorization: Bearer YOUR_TOKEN`, an API-key header, or a query key — whatever the scheme calls for). There's nothing to configure: Blume reads `security` from the spec, so the reference always matches what the API actually enforces.
+
+The OpenAPI semantics carry over as written:
+
+- An operation's own `security` overrides the document's root default; `security: []` marks it **public** and renders no Authorization section.
+- Multiple requirement entries are alternatives — rendered as "or" groups; every scheme inside one entry is required together. The first alternative feeds the code samples.
+- An empty `{}` entry means auth is **optional** for that operation, and the section says so.
+- OAuth2 scopes are listed per scheme; scheme `description`s from `components.securitySchemes` render inline.
+
 ## The Scalar renderer
 
 The native renderer is the default. If you'd rather embed [Scalar](https://scalar.com)'s self-contained API reference — its own sidebar, search, theme, and "Try it" playground on a single route — set `renderer: "scalar"`:

--- a/packages/blume/src/components/openapi/Authorization.astro
+++ b/packages/blume/src/components/openapi/Authorization.astro
@@ -1,0 +1,80 @@
+---
+import {
+  type OperationSecurity,
+  schemeCarrier,
+  schemeLabel,
+} from "./security.ts";
+
+interface Props {
+  security: OperationSecurity;
+}
+
+const { security } = Astro.props;
+---
+
+{
+  security.alternatives.length > 0 && (
+    <section class="mt-6">
+      <div
+        aria-level="3"
+        class="mb-2 font-semibold text-foreground text-sm"
+        role="heading"
+      >
+        Authorization
+      </div>
+      {security.optional && (
+        <p class="mb-2 text-muted-foreground text-sm">
+          Optional — this operation also accepts unauthenticated requests.
+        </p>
+      )}
+      {security.alternatives.map((alternative, index) => (
+        <>
+          {index > 0 && (
+            <div class="my-2 font-medium text-[0.625rem] text-muted-foreground uppercase tracking-wide">
+              or
+            </div>
+          )}
+          <div class="not-prose rounded-blume border border-border px-4">
+            {alternative.map((resolved) => {
+              const carrier = schemeCarrier(resolved);
+              return (
+                <div class="border-border border-t py-3 first:border-t-0">
+                  <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <code class="font-mono text-foreground text-sm">
+                      {carrier?.name ?? resolved.key}
+                    </code>
+                    <span class="text-muted-foreground text-xs">
+                      {schemeLabel(resolved)}
+                      {carrier ? ` · ${carrier.in}` : ""}
+                    </span>
+                    {!security.optional && (
+                      <span class="font-medium text-[0.625rem] text-red-600 uppercase tracking-wide dark:text-red-400">
+                        required
+                      </span>
+                    )}
+                  </div>
+                  {resolved.scheme?.description && (
+                    <div
+                      class="mt-1 text-muted-foreground text-sm"
+                      set:text={resolved.scheme.description}
+                    />
+                  )}
+                  {resolved.scopes.length > 0 && (
+                    <div class="mt-1 flex flex-wrap items-center gap-1 text-xs">
+                      <span class="text-muted-foreground">Scopes:</span>
+                      {resolved.scopes.map((scope) => (
+                        <code class="rounded bg-muted px-1 py-0.5 text-foreground">
+                          {scope}
+                        </code>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      ))}
+    </section>
+  )
+}

--- a/packages/blume/src/components/openapi/Operation.astro
+++ b/packages/blume/src/components/openapi/Operation.astro
@@ -6,7 +6,15 @@ import {
   resolveComponentRef,
   type SchemaLike,
 } from "./helpers.ts";
+import {
+  effectiveSecurity,
+  resolveSecurity,
+  sampleAuth,
+  type SecurityRequirementLike,
+  type SecuritySchemeLike,
+} from "./security.ts";
 import { buildRequestSample, sampleLanguages } from "./snippets.ts";
+import Authorization from "./Authorization.astro";
 import MethodBadge from "./MethodBadge.astro";
 import ParametersTable from "./ParametersTable.astro";
 import RequestBody from "./RequestBody.astro";
@@ -43,6 +51,7 @@ interface FullOperation {
   parameters?: ParameterLike[];
   requestBody?: RequestBodyLike;
   responses?: Record<string, ResponseLike>;
+  security?: SecurityRequirementLike[];
 }
 
 const { source, id } = Astro.props;
@@ -59,7 +68,9 @@ const doc = (spec?.document ?? {}) as {
     parameters?: Record<string, ParameterLike>;
     requestBodies?: Record<string, RequestBodyLike>;
     responses?: Record<string, ResponseLike>;
+    securitySchemes?: Record<string, SecuritySchemeLike>;
   };
+  security?: SecurityRequirementLike[];
   servers?: { url?: string }[];
 };
 const pathItem = ref ? doc.paths?.[ref.path] : undefined;
@@ -84,6 +95,11 @@ const responses = Object.fromEntries(
   ])
 );
 
+const security = resolveSecurity(
+  effectiveSecurity(operation?.security, doc.security),
+  doc.components?.securitySchemes
+);
+
 const sample =
   ref && operation
     ? buildRequestSample(
@@ -91,7 +107,8 @@ const sample =
         ref.method,
         ref.path,
         doc.servers ?? [],
-        schemas
+        schemas,
+        sampleAuth(security)
       )
     : null;
 const languages = sampleLanguages(spec?.codeSamples ?? []);
@@ -115,6 +132,7 @@ const languages = sampleLanguages(spec?.codeSamples ?? []);
       </div>
       <div class="grid grid-cols-1 items-start gap-x-10 gap-y-8 xl:grid-cols-[minmax(0,1fr)_minmax(0,28rem)]">
         <div>
+          <Authorization security={security} />
           <ParametersTable parameters={params} schemas={schemas} />
           {requestBody && (
             <RequestBody

--- a/packages/blume/src/components/openapi/security.ts
+++ b/packages/blume/src/components/openapi/security.ts
@@ -1,0 +1,201 @@
+/**
+ * Security (authorization) resolution for the OpenAPI components. An operation
+ * enforces its own `security` when declared — an empty array explicitly makes
+ * it public — and inherits the document's root `security` otherwise. Within the
+ * resolved list, each requirement object is one way to authorize (OR between
+ * entries), and every scheme named inside a single requirement is needed
+ * together (AND). Pure and dependency-free like `helpers.ts`, so it runs in the
+ * browser build with no server-only imports.
+ */
+
+/** A permissive view of an OpenAPI security scheme — only the fields we render. */
+export interface SecuritySchemeLike {
+  type?: string;
+  description?: string;
+  /** `apiKey`: the parameter name the key is sent as. */
+  name?: string;
+  /** `apiKey`: where the key goes — `header`, `query`, or `cookie`. */
+  in?: string;
+  /** `http`: the HTTP auth scheme, e.g. `bearer` or `basic`. */
+  scheme?: string;
+  /** `http` bearer: a hint at the token format, e.g. `JWT`. */
+  bearerFormat?: string;
+  [key: string]: unknown;
+}
+
+/** One security requirement: scheme name -> required scopes (empty outside OAuth). */
+export type SecurityRequirementLike = Record<string, string[]>;
+
+/** A scheme resolved out of `components.securitySchemes`, with its scopes. */
+export interface ResolvedScheme {
+  /** The scheme's component name, e.g. `bearerAuth`. */
+  key: string;
+  /** The scheme object; undefined when the requirement names an unknown one. */
+  scheme?: SecuritySchemeLike;
+  scopes: string[];
+}
+
+/** The security state one operation renders. */
+export interface OperationSecurity {
+  /** Ways to authorize (OR); every scheme within one entry is required (AND). */
+  alternatives: ResolvedScheme[][];
+  /** True when an empty requirement also allows unauthenticated calls. */
+  optional: boolean;
+}
+
+/**
+ * The requirement list an operation actually enforces: its own `security` when
+ * declared — the OpenAPI override rule, where `[]` removes the default and
+ * makes the operation public — else the document's root `security`.
+ */
+export const effectiveSecurity = (
+  operation?: SecurityRequirementLike[],
+  document?: SecurityRequirementLike[]
+): SecurityRequirementLike[] => operation ?? document ?? [];
+
+/**
+ * Resolve requirement names against `components.securitySchemes`. A name with
+ * no matching component is kept (with `scheme` undefined) so an inconsistent
+ * spec still renders the requirement instead of silently dropping it. An empty
+ * requirement object — the spec idiom for "auth optional" — contributes no
+ * alternative and flips `optional` instead.
+ */
+export const resolveSecurity = (
+  requirements: SecurityRequirementLike[],
+  schemes: Record<string, SecuritySchemeLike> | undefined
+): OperationSecurity => {
+  const alternatives: ResolvedScheme[][] = [];
+  let optional = false;
+  for (const requirement of requirements) {
+    const entries = Object.entries(requirement ?? {});
+    if (entries.length === 0) {
+      optional = true;
+      continue;
+    }
+    alternatives.push(
+      entries.map(([key, scopes]) => ({
+        key,
+        scheme: schemes?.[key],
+        scopes: Array.isArray(scopes)
+          ? scopes.filter((scope): scope is string => typeof scope === "string")
+          : [],
+      }))
+    );
+  }
+  return { alternatives, optional };
+};
+
+const capitalize = (text: string): string =>
+  text.charAt(0).toUpperCase() + text.slice(1);
+
+/** A short human label for a scheme row, e.g. `Bearer token` or `API key`. */
+export const schemeLabel = (resolved: ResolvedScheme): string => {
+  const { scheme } = resolved;
+  switch (scheme?.type) {
+    case "http": {
+      const kind = (scheme.scheme ?? "").toLowerCase();
+      if (kind === "bearer") {
+        return scheme.bearerFormat
+          ? `Bearer token (${scheme.bearerFormat})`
+          : "Bearer token";
+      }
+      if (kind === "basic") {
+        return "Basic auth";
+      }
+      return kind ? `HTTP ${kind}` : "HTTP auth";
+    }
+    case "apiKey": {
+      return "API key";
+    }
+    case "oauth2": {
+      return "OAuth2 access token";
+    }
+    case "openIdConnect": {
+      return "OpenID Connect token";
+    }
+    case "mutualTLS": {
+      return "Mutual TLS";
+    }
+    default: {
+      // Unknown scheme ref: the component name is the best label available.
+      return resolved.key;
+    }
+  }
+};
+
+/**
+ * Where the credential travels: the header/query/cookie parameter it occupies.
+ * Undefined for schemes with no request parameter (mutual TLS) and for unknown
+ * refs, where guessing a location would be misleading.
+ */
+export const schemeCarrier = (
+  resolved: ResolvedScheme
+): { name: string; in: string } | undefined => {
+  const { scheme } = resolved;
+  switch (scheme?.type) {
+    case "http":
+    case "oauth2":
+    case "openIdConnect": {
+      return { in: "header", name: "Authorization" };
+    }
+    case "apiKey": {
+      return { in: scheme.in ?? "header", name: scheme.name ?? resolved.key };
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+/** Placeholder credentials the request samples send. */
+export interface SampleAuth {
+  headers: Record<string, string>;
+  query: Record<string, string>;
+}
+
+/**
+ * Placeholder credentials for an operation's request samples, from its first
+ * alternative (the spec's preferred way to authorize). Schemes that don't
+ * travel in the request (mutual TLS) and unknown refs contribute nothing.
+ */
+export const sampleAuth = (security: OperationSecurity): SampleAuth => {
+  const headers: Record<string, string> = {};
+  const query: Record<string, string> = {};
+  const cookies: string[] = [];
+  for (const resolved of security.alternatives[0] ?? []) {
+    const { scheme } = resolved;
+    switch (scheme?.type) {
+      case "http": {
+        const kind = (scheme.scheme ?? "bearer").toLowerCase();
+        headers.Authorization =
+          kind === "bearer"
+            ? "Bearer YOUR_TOKEN"
+            : `${capitalize(kind)} YOUR_CREDENTIALS`;
+        break;
+      }
+      case "oauth2":
+      case "openIdConnect": {
+        headers.Authorization = "Bearer YOUR_ACCESS_TOKEN";
+        break;
+      }
+      case "apiKey": {
+        const name = scheme.name ?? resolved.key;
+        if (scheme.in === "query") {
+          query[name] = "YOUR_API_KEY";
+        } else if (scheme.in === "cookie") {
+          cookies.push(`${name}=YOUR_API_KEY`);
+        } else {
+          headers[name] = "YOUR_API_KEY";
+        }
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+  if (cookies.length > 0) {
+    headers.Cookie = cookies.join("; ");
+  }
+  return { headers, query };
+};

--- a/packages/blume/src/components/openapi/snippets.ts
+++ b/packages/blume/src/components/openapi/snippets.ts
@@ -1,5 +1,6 @@
 import { exampleValue, toJson } from "./helpers.ts";
 import type { SchemaLike } from "./helpers.ts";
+import type { SampleAuth } from "./security.ts";
 
 /**
  * Request example + code-sample generation for an operation. Kept separate from
@@ -43,10 +44,14 @@ const jsonContentType = (
   return entries.find(([type]) => type.includes("json")) ?? entries[0];
 };
 
-/** The `?a=1&b=2` query string from an operation's required query params. */
+/**
+ * The `?a=1&b=2` query string from an operation's required query params, plus
+ * any extra entries (a query-borne API key from the security requirements).
+ */
 const queryString = (
   params: ParamLike[],
-  schemas: Record<string, SchemaLike>
+  schemas: Record<string, SchemaLike>,
+  extra: Record<string, string>
 ): string => {
   const query: string[] = [];
   for (const param of params) {
@@ -60,7 +65,31 @@ const queryString = (
       )}`
     );
   }
+  for (const [name, value] of Object.entries(extra)) {
+    query.push(`${encodeURIComponent(name)}=${encodeURIComponent(value)}`);
+  }
   return query.length > 0 ? `?${query.join("&")}` : "";
+};
+
+/**
+ * The sample's headers: auth placeholders first, so a spec that also declares
+ * the credential as an explicit header parameter overrides them with its own
+ * (better) example.
+ */
+const headerValues = (
+  params: ParamLike[],
+  schemas: Record<string, SchemaLike>,
+  auth: SampleAuth | undefined
+): Record<string, string> => {
+  const headers: Record<string, string> = { ...auth?.headers };
+  for (const param of params) {
+    if (param.in === "header" && param.required && param.name) {
+      headers[param.name] = String(
+        param.example ?? exampleValue(param.schema, schemas) ?? ""
+      );
+    }
+  }
+  return headers;
 };
 
 /** Assemble a representative request from an operation and the spec servers. */
@@ -69,7 +98,8 @@ export const buildRequestSample = (
   method: string,
   path: string,
   servers: { url?: string }[],
-  schemas: Record<string, SchemaLike>
+  schemas: Record<string, SchemaLike>,
+  auth?: SampleAuth
 ): RequestSample => {
   const base = (servers[0]?.url ?? "").replace(TRAILING_SLASH, "");
   const params = operation.parameters ?? [];
@@ -85,16 +115,8 @@ export const buildRequestSample = (
     }
   }
 
-  const search = queryString(params, schemas);
-
-  const headers: Record<string, string> = {};
-  for (const param of params) {
-    if (param.in === "header" && param.required && param.name) {
-      headers[param.name] = String(
-        param.example ?? exampleValue(param.schema, schemas) ?? ""
-      );
-    }
-  }
+  const search = queryString(params, schemas, auth?.query ?? {});
+  const headers = headerValues(params, schemas, auth);
 
   const media = jsonContentType(operation.requestBody?.content);
   let body: string | undefined;

--- a/packages/blume/test/openapi.test.ts
+++ b/packages/blume/test/openapi.test.ts
@@ -18,6 +18,13 @@ import {
 } from "../src/components/openapi/helpers.ts";
 import type { SchemaLike } from "../src/components/openapi/helpers.ts";
 import {
+  effectiveSecurity,
+  resolveSecurity,
+  sampleAuth,
+  schemeCarrier,
+  schemeLabel,
+} from "../src/components/openapi/security.ts";
+import {
   buildRequestSample,
   sampleLanguages,
 } from "../src/components/openapi/snippets.ts";
@@ -1381,5 +1388,222 @@ describe("snippets", () => {
       "js",
       "python",
     ]);
+  });
+});
+
+describe("security", () => {
+  const SCHEMES = {
+    apiCookie: { in: "cookie", name: "session", type: "apiKey" },
+    apiHeader: {
+      description: "Key from the dashboard.",
+      in: "header",
+      name: "X-Api-Key",
+      type: "apiKey",
+    },
+    apiQuery: { in: "query", name: "api_key", type: "apiKey" },
+    basicAuth: { scheme: "basic", type: "http" },
+    bearerAuth: { bearerFormat: "JWT", scheme: "bearer", type: "http" },
+    oauth: { type: "oauth2" },
+    oidc: { type: "openIdConnect" },
+    tls: { type: "mutualTLS" },
+  };
+
+  it("prefers the operation's security and treats [] as public", () => {
+    const root = [{ bearerAuth: [] }];
+    expect(effectiveSecurity(undefined, root)).toStrictEqual(root);
+    expect(effectiveSecurity([], root)).toStrictEqual([]);
+    expect(effectiveSecurity([{ apiHeader: [] }], root)).toStrictEqual([
+      { apiHeader: [] },
+    ]);
+    expect(effectiveSecurity()).toStrictEqual([]);
+  });
+
+  it("resolves requirement names against the component schemes", () => {
+    const { alternatives, optional } = resolveSecurity(
+      [{ bearerAuth: [] }, { apiHeader: [], apiQuery: [] }],
+      SCHEMES
+    );
+    expect(optional).toBe(false);
+    // Two OR alternatives; the second requires both schemes together.
+    expect(alternatives).toHaveLength(2);
+    expect(alternatives[0]?.[0]?.scheme).toBe(SCHEMES.bearerAuth);
+    expect(alternatives[1]?.map((entry) => entry.key)).toStrictEqual([
+      "apiHeader",
+      "apiQuery",
+    ]);
+  });
+
+  it("keeps an unknown scheme ref instead of dropping the requirement", () => {
+    const { alternatives } = resolveSecurity([{ ghost: [] }], SCHEMES);
+    expect(alternatives[0]?.[0]).toStrictEqual({
+      key: "ghost",
+      scheme: undefined,
+      scopes: [],
+    });
+  });
+
+  it("flags an empty requirement as optional auth, not an alternative", () => {
+    const { alternatives, optional } = resolveSecurity(
+      [{}, { bearerAuth: [] }],
+      SCHEMES
+    );
+    expect(optional).toBe(true);
+    expect(alternatives).toHaveLength(1);
+  });
+
+  it("carries OAuth scopes and ignores malformed entries", () => {
+    const { alternatives } = resolveSecurity(
+      [{ oauth: ["read:pets", "write:pets"] }],
+      SCHEMES
+    );
+    expect(alternatives[0]?.[0]?.scopes).toStrictEqual([
+      "read:pets",
+      "write:pets",
+    ]);
+    const malformed = resolveSecurity(
+      [{ oauth: "read" }] as unknown as Record<string, string[]>[],
+      SCHEMES
+    );
+    expect(malformed.alternatives[0]?.[0]?.scopes).toStrictEqual([]);
+  });
+
+  it("labels schemes and locates their credential", () => {
+    const resolved = (key: keyof typeof SCHEMES) => ({
+      key,
+      scheme: SCHEMES[key],
+      scopes: [],
+    });
+    expect(schemeLabel(resolved("bearerAuth"))).toBe("Bearer token (JWT)");
+    expect(schemeLabel(resolved("basicAuth"))).toBe("Basic auth");
+    expect(schemeLabel(resolved("apiHeader"))).toBe("API key");
+    expect(schemeLabel(resolved("oauth"))).toBe("OAuth2 access token");
+    expect(schemeLabel(resolved("oidc"))).toBe("OpenID Connect token");
+    expect(schemeLabel(resolved("tls"))).toBe("Mutual TLS");
+    // A format-less bearer and a non-bearer/basic HTTP scheme.
+    expect(
+      schemeLabel({
+        key: "plain",
+        scheme: { scheme: "bearer", type: "http" },
+        scopes: [],
+      })
+    ).toBe("Bearer token");
+    expect(
+      schemeLabel({
+        key: "digest",
+        scheme: { scheme: "digest", type: "http" },
+        scopes: [],
+      })
+    ).toBe("HTTP digest");
+    // Unknown ref: the component name is the only label available.
+    expect(schemeLabel({ key: "ghost", scopes: [] })).toBe("ghost");
+
+    expect(schemeCarrier(resolved("bearerAuth"))).toStrictEqual({
+      in: "header",
+      name: "Authorization",
+    });
+    expect(schemeCarrier(resolved("apiQuery"))).toStrictEqual({
+      in: "query",
+      name: "api_key",
+    });
+    expect(schemeCarrier(resolved("tls"))).toBeUndefined();
+    expect(schemeCarrier({ key: "ghost", scopes: [] })).toBeUndefined();
+  });
+
+  it("builds placeholder credentials from the first alternative only", () => {
+    const security = resolveSecurity(
+      [{ apiCookie: [], apiHeader: [], apiQuery: [], bearerAuth: [] }],
+      SCHEMES
+    );
+    const auth = sampleAuth(security);
+    expect(auth.headers.Authorization).toBe("Bearer YOUR_TOKEN");
+    expect(auth.headers["X-Api-Key"]).toBe("YOUR_API_KEY");
+    expect(auth.headers.Cookie).toBe("session=YOUR_API_KEY");
+    expect(auth.query).toStrictEqual({ api_key: "YOUR_API_KEY" });
+
+    const second = sampleAuth(
+      resolveSecurity([{ basicAuth: [] }, { apiHeader: [] }], SCHEMES)
+    );
+    expect(second.headers).toStrictEqual({
+      Authorization: "Basic YOUR_CREDENTIALS",
+    });
+
+    // OAuth2 (and OpenID Connect) degrade to a bearer access token.
+    expect(
+      sampleAuth(resolveSecurity([{ oauth: ["read:pets"] }], SCHEMES)).headers
+    ).toStrictEqual({ Authorization: "Bearer YOUR_ACCESS_TOKEN" });
+
+    // Mutual TLS travels outside the request; an unknown ref can't be guessed.
+    expect(
+      sampleAuth(resolveSecurity([{ ghost: [], tls: [] }], SCHEMES))
+    ).toStrictEqual({ headers: {}, query: {} });
+
+    // Public operation: nothing to add.
+    expect(sampleAuth(resolveSecurity([], SCHEMES))).toStrictEqual({
+      headers: {},
+      query: {},
+    });
+  });
+
+  it("threads auth placeholders into the request sample and snippets", () => {
+    const security = resolveSecurity([{ bearerAuth: [] }], SCHEMES);
+    const sample = buildRequestSample(
+      { parameters: [] },
+      "post",
+      "/pet",
+      [{ url: "https://api.test/v1" }],
+      {},
+      sampleAuth(security)
+    );
+    expect(sample.headers.Authorization).toBe("Bearer YOUR_TOKEN");
+    const [curl] = sampleLanguages(["curl"]).map((language) =>
+      language.build(sample)
+    );
+    expect(curl).toContain('-H "Authorization: Bearer YOUR_TOKEN"');
+  });
+
+  it("appends a query API key to the sample URL", () => {
+    const security = resolveSecurity([{ apiQuery: [] }], SCHEMES);
+    const sample = buildRequestSample(
+      {
+        parameters: [
+          {
+            in: "query",
+            name: "verbose",
+            required: true,
+            schema: { type: "boolean" },
+          },
+        ],
+      },
+      "get",
+      "/pet",
+      [{ url: "https://api.test/v1" }],
+      {},
+      sampleAuth(security)
+    );
+    expect(sample.url).toBe(
+      "https://api.test/v1/pet?verbose=true&api_key=YOUR_API_KEY"
+    );
+  });
+
+  it("lets an explicit header parameter override the auth placeholder", () => {
+    const security = resolveSecurity([{ bearerAuth: [] }], SCHEMES);
+    const sample = buildRequestSample(
+      {
+        parameters: [
+          {
+            example: "Bearer from-the-spec",
+            in: "header",
+            name: "Authorization",
+            required: true,
+          },
+        ],
+      },
+      "get",
+      "/pet",
+      [{ url: "https://api.test/v1" }],
+      {},
+      sampleAuth(security)
+    );
+    expect(sample.headers.Authorization).toBe("Bearer from-the-spec");
   });
 });


### PR DESCRIPTION
The renderer ignored security entirely, so authenticated endpoints were indistinguishable from public ones. Operations now show an Authorization section above their parameters — resolved from the operation's security (or the document root default) against components.securitySchemes — and the code samples send a matching placeholder credential.

OpenAPI semantics carry over as written: security: [] keeps an operation public, requirement entries render as "or" alternatives with the schemes inside one entry required together, an empty {} entry marks auth as optional, and OAuth scopes and scheme descriptions render per scheme. A requirement naming an unknown scheme is kept (labelled by its component name) instead of dropped. Samples take the first alternative; an explicit spec-declared header parameter still overrides the placeholder.

## Description

Please provide a brief description of the changes introduced in this pull request.

## Related Issues

Closes #<issue_number>

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

<img width="1796" height="700" alt="Screenshot 2026-07-16 at 11 39 35 AM" src="https://github.com/user-attachments/assets/d2f82d66-fd7a-4774-8961-37e0f9ed7d44" />


## Additional Notes

You can see example from screenshot at test docs site [here](https://garage-docs-blume.grovemotorco.workers.dev/reference/operations/agents-claimview/). Please suggest any changes - happy to edit as needed.
