### PR TITLE
Fix pnpm isolated linker dependency resolution

### DIFF
--- a/.changeset/fix-pnpm-node-path.md
+++ b/.changeset/fix-pnpm-node-path.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Fix `blume dev` under pnpm's default isolated linker. The generated runtime now checks Astro through the same physical `node_modules` ancestor lookup used by its ESM config, instead of mistaking pnpm's CommonJS-only `NODE_PATH` exposure for a resolvable `astro/config` import.

--- a/packages/blume/src/astro/generate.ts
+++ b/packages/blume/src/astro/generate.ts
@@ -149,20 +149,39 @@ const reactCompilerWarnings = (
       ]
     : [];
 
-/**
- * Realpath of the `astro` package node resolves from a directory, or null when
- * none resolves. Comparing this for `.blume/` against Blume's own deps tells
- * whether the runtime would bind to the *same* astro Blume uses or a different
- * one shadowing it (the hoisted-conflict failure mode).
- */
-const resolvedAstroPath = (fromDir: string): string | null => {
+/** Resolve Astro's package.json directly inside a node_modules directory. */
+const resolveAstroPackageJson = (modulesDir: string): string | null => {
   try {
-    const pkg = createRequire(
-      pathToFileURL(join(fromDir, "_.js")).href
-    ).resolve("astro/package.json");
-    return realpathSync(pkg);
+    return realpathSync(join(modulesDir, "astro", "package.json"));
   } catch {
     return null;
+  }
+};
+
+/**
+ * Realpath of the `astro` package reachable through the normal node_modules
+ * ancestor walk from a generated runtime, or null when none resolves.
+ *
+ * This deliberately does not use `createRequire().resolve()`. pnpm's generated
+ * bin shim adds Blume's virtual-store dependencies to `NODE_PATH`, which
+ * CommonJS resolution honors but ESM package resolution ignores. The generated
+ * Astro config uses ESM imports, so treating a NODE_PATH-only result as
+ * reachable skips the dependency link and makes `import "astro/config"` fail.
+ * Walking the physical node_modules ancestors mirrors the lookup that config
+ * actually gets.
+ */
+const resolvedAstroPath = (fromDir: string): string | null => {
+  let dir = normalize(fromDir);
+  while (true) {
+    const resolved = resolveAstroPackageJson(join(dir, "node_modules"));
+    if (resolved) {
+      return resolved;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
   }
 };
 
@@ -282,7 +301,7 @@ export const ensureDepsLink = async (
   }
   // Already correct when `.blume/` resolves the very same astro Blume's deps
   // provide — the clean hoisted case, nothing to do.
-  const blumeAstro = resolvedAstroPath(depsDir);
+  const blumeAstro = resolveAstroPackageJson(depsDir);
   const outDirAstro = resolvedAstroPath(outDir);
   if (blumeAstro && outDirAstro === blumeAstro) {
     return null;

--- a/packages/blume/test/deps-link.test.ts
+++ b/packages/blume/test/deps-link.test.ts
@@ -153,6 +153,39 @@ describe("ensureDepsLink", () => {
     expect(existsSync(join(link, "astro", "package.json"))).toBe(true);
   });
 
+  it("links when pnpm's bin shim exposes Astro only through NODE_PATH", async () => {
+    const { outDir, pkgDir, store } = await isolatedFixture();
+    const generateUrl = pathToFileURL(
+      join(import.meta.dir, "../src/astro/generate.ts")
+    ).href;
+    const script = `
+      const { ensureDepsLink } = await import(${JSON.stringify(generateUrl)});
+      await ensureDepsLink(${JSON.stringify(outDir)}, ${JSON.stringify(pkgDir)});
+    `;
+
+    // pnpm's generated `node_modules/.bin/blume` wrapper prepends this virtual
+    // store directory to NODE_PATH. CommonJS `require.resolve` sees Astro there,
+    // while the generated config's ESM `import "astro/config"` does not. Run in
+    // a child process because NODE_PATH is read when the runtime starts.
+    const proc = Bun.spawn([process.execPath, "-e", script], {
+      env: { ...process.env, NODE_PATH: store },
+      stderr: "pipe",
+      stdout: "ignore",
+    });
+    const [exitCode, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(stderr);
+    }
+
+    const link = join(outDir, "node_modules");
+    const stats = await lstat(link);
+    expect(stats.isSymbolicLink()).toBe(true);
+    expect(await readlink(link)).toBe(store);
+  });
+
   it("is a no-op when Astro already resolves (hoisted install)", async () => {
     const outDir = join(root, "app", ".blume");
     await mkdir(join(root, "app", "node_modules"), { recursive: true });

--- a/packages/blume/test/generate.test.ts
+++ b/packages/blume/test/generate.test.ts
@@ -997,8 +997,8 @@ describe("ensureDepsLink version-less conflict", () => {
 
   it("degrades to a version-less warning when neither Astro resolves", async () => {
     // A split layout where the `astro` directory holds no package.json, so
-    // `resolvedAstroPath` yields null and `readPkgVersion` takes its null-path
-    // guard — the diagnostic falls back to its version-less form.
+    // The direct Astro package lookup yields null and `readPkgVersion` takes its
+    // null-path guard — the diagnostic falls back to its version-less form.
     const dir = await mkdtemp(join(tmpdir(), "blume-conflict-"));
     conflictDirs.push(dir);
     const pkgDir = join(dir, "node_modules", "blume");


### PR DESCRIPTION
## Description

Fix `blume dev` under pnpm's default isolated linker.

pnpm's generated CLI wrapper exposes Blume's dependencies through `NODE_PATH`, which CommonJS resolution honors but ESM resolution ignores. This caused Blume's dependency preflight to incorrectly conclude that `astro/config` was reachable from the generated `.blume` runtime.

The runtime now checks physical `node_modules` ancestors, matching the ESM resolution used by the generated Astro config. A regression test reproduces pnpm's `NODE_PATH` environment.

## Related Issues

Closes #72

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

Not applicable — this change has no UI impact.

## Additional Notes

Verified end to end with a locally packed tarball under pnpm's default isolated linker. `blume dev` starts successfully and creates the expected `.blume/node_modules` link.