### PR TITLE
Let served assets satisfy the audit's llms.txt stale-entry check

### DIFF
--- a/.changeset/shiny-crabs-listen.md
+++ b/.changeset/shiny-crabs-listen.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Stop `blume audit` flagging the changelog RSS feed link in llms.txt as a stale entry. The stale-entry check compared each llms.txt target against built pages only, but the generator itself links non-page assets — the changelog RSS feed — so a target the static file index serves now counts as valid, the same way redirect targets may land on a served asset.

--- a/packages/blume/src/audit/checks/llms.ts
+++ b/packages/blume/src/audit/checks/llms.ts
@@ -91,7 +91,10 @@ export const llmsChecks: CheckModule = {
         continue;
       }
       listed.add(path);
-      if (!context.byUrl.has(path)) {
+      // A listed target may be a served asset rather than a page — Blume's own
+      // llms.txt links the changelog RSS feed — so the file index vouches for
+      // it too, the same way redirect targets may land on a served asset.
+      if (!context.byUrl.has(path) && !context.files.has(path)) {
         found.push(
           finding(
             "BLUME_AUDIT_LLMS_TXT_STALE_ENTRY",

--- a/packages/blume/test/audit-checks.test.ts
+++ b/packages/blume/test/audit-checks.test.ts
@@ -1450,6 +1450,21 @@ describe("llms.txt checks", () => {
     expect(run(llmsChecks, ctx)).toContain("LLMS_TXT_STALE_ENTRY");
   });
 
+  it("accepts an entry that resolves to a served asset", () => {
+    // The generator itself links non-page assets — the changelog RSS feed —
+    // so a target the file index vouches for is not stale.
+    const ctx = context({
+      files: new Map([["/changelog/rss.xml", 512]]),
+      llms: {
+        entries: [{ line: 3, url: "https://x.dev/changelog/rss.xml" }],
+        file: "/dist/llms.txt",
+      },
+      pages: [snapshot({ url: "/" })],
+      site: SITE,
+    });
+    expect(run(llmsChecks, ctx)).not.toContain("LLMS_TXT_STALE_ENTRY");
+  });
+
   it("reports an indexable nav page that is not listed", () => {
     const ctx = context({
       llms: {


### PR DESCRIPTION
## Description

Thanks for 1.1.0! I upgraded right away — `seo.og.fonts` renders our Japanese OG cards perfectly (no more tofu, so I could finally drop the local font patch from #62), and the locale-aware changelog dates from #78 let me drop my other patch too. Zero patches now 🎉

While trying the new `blume audit` on the upgraded site, I hit what I think is a small false positive:

 ```
⚠ llms.txt lists a page the build does not serve
    https://h-kono-it.github.io/legal-check-helper/changelog/rss.xml  dist/llms.txt:99
```

but `dist/changelog/rss.xml` does exist in the build output. I think this is two 1.1.0 features meeting: llms.txt now includes RSS feed links, while `LLMS_TXT_STALE_ENTRY` resolves each entry against `context.byUrl`, which only contains HTML pages — so the feed link the generator itself emits is always flagged. Reproducible on any site with changelog entries and RSS enabled (both defaults).

This change also accepts any path the static file index serves, mirroring how `resolveRedirects` already composes pages + files into the served set.

Verified against a real site: on the same 1.1.0 build, stock `blume audit` flags `/changelog/rss.xml`; with this change the warning is gone and the rest of the report is unchanged.

## Related Issues

None — reporting and fixing in one go; happy to split out an issue if you prefer.

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary