### PR TITLE
Support custom syntax highlighting themes

### DIFF
--- a/.changeset/custom-shiki-themes.md
+++ b/.changeset/custom-shiki-themes.md
@@ -1,5 +1,5 @@
 ---
-"blume": minor
+"blume": patch
 ---
 
 Allow custom Shiki theme objects in `markdown.codeBlocks.theme.light` and `markdown.codeBlocks.theme.dark`. Custom themes now flow through fenced code, inline highlighted code, `<CodeBlock>`, and `<Diff>` alongside bundled Shiki theme names.

--- a/.changeset/custom-shiki-themes.md
+++ b/.changeset/custom-shiki-themes.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Allow custom Shiki theme objects in `markdown.codeBlocks.theme.light` and `markdown.codeBlocks.theme.dark`. Custom themes now flow through fenced code, inline highlighted code, `<CodeBlock>`, and `<Diff>` alongside bundled Shiki theme names.

--- a/apps/docs/content/docs/configuration/index.mdx
+++ b/apps/docs/content/docs/configuration/index.mdx
@@ -55,7 +55,7 @@ export default defineConfig({
     },
     codeBlocks: {
       theme: {
-        light: "github-light", // any bundled Shiki theme
+        light: "github-light", // bundled name or custom Shiki theme object
         dark: "github-dark",
       },
     },

--- a/apps/docs/content/docs/content/syntax.mdx
+++ b/apps/docs/content/docs/content/syntax.mdx
@@ -154,6 +154,20 @@ export default defineConfig({
 });
 ```
 
+You can also provide a custom [Shiki theme definition](https://shiki.style/guide/load-theme) directly. Import a VS Code-compatible theme JSON file (using an import attribute when your runtime requires one) and assign it to either color mode; bundled names and custom definitions can be mixed:
+
+```ts blume.config.ts
+import darkTheme from "./themes/acme-dark.json" with { type: "json" };
+
+export default defineConfig({
+  markdown: {
+    codeBlocks: {
+      theme: { light: "github-light", dark: darkTheme },
+    },
+  },
+});
+```
+
 ### Line numbers
 
 Append `lineNumbers` to render a line-number gutter — on its own or alongside a title:

--- a/packages/blume/src/components/content/diff.ts
+++ b/packages/blume/src/components/content/diff.ts
@@ -8,13 +8,15 @@
  * a unified patch (string or `.patch`/`.diff` file), a pair of file paths, or a
  * pair of inline strings.
  */
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
+import { registerCustomTheme } from "@pierre/diffs";
 import { preloadDiffHTML, preloadPatchDiff } from "@pierre/diffs/ssr";
 import { isAbsolute, join } from "pathe";
 
 import { DEFAULT_CODE_THEMES } from "../../markdown/themes.ts";
-import type { CodeThemes } from "../../markdown/themes.ts";
+import type { CodeTheme, CodeThemes } from "../../markdown/themes.ts";
 
 export interface DiffOptions {
   /** Path to the "after" file, resolved relative to {@link DiffOptions.root}. */
@@ -46,6 +48,39 @@ const resolvePath = (path: string, root: string): string =>
 const readText = (path: string, root: string): Promise<string> =>
   readFile(resolvePath(path, root), "utf-8");
 
+const registeredDiffThemes = new WeakMap<object, string>();
+
+/**
+ * Pierre accepts custom Shiki themes through its registry, while Shiki itself
+ * accepts the object directly. Register each configured object under a name
+ * derived from its content so registration survives dev-server reloads: the
+ * same theme re-registers under the same name (harmless overwrite), and an
+ * edited theme gets a fresh name instead of a stale cached entry.
+ */
+const diffThemeName = (theme: CodeTheme, mode: "dark" | "light"): string => {
+  if (typeof theme === "string") {
+    return theme;
+  }
+  const cached = registeredDiffThemes.get(theme);
+  if (cached) {
+    return cached;
+  }
+  const hash = createHash("sha256")
+    .update(JSON.stringify(theme))
+    .digest("hex")
+    .slice(0, 12);
+  const name = `blume-custom-${mode}-${hash}`;
+  const registered = { ...theme, name, type: theme.type ?? mode };
+  registerCustomTheme(name, () => Promise.resolve(registered));
+  registeredDiffThemes.set(theme, name);
+  return name;
+};
+
+const diffThemes = (themes: CodeThemes): { dark: string; light: string } => ({
+  dark: diffThemeName(themes.dark, "dark"),
+  light: diffThemeName(themes.light, "light"),
+});
+
 /**
  * Resolve `<Diff>` inputs to a prerendered HTML string. Throws when no input
  * group is supplied or a pair is half-specified, so the component can degrade
@@ -67,7 +102,7 @@ export const renderDiff = async (options: DiffOptions): Promise<string> => {
   if (patch !== undefined || src !== undefined) {
     const text = patch ?? (await readText(src as string, root));
     const result = await preloadPatchDiff({
-      options: { theme },
+      options: { theme: diffThemes(theme) },
       patch: text,
     });
     return result.prerenderedHTML;
@@ -80,7 +115,7 @@ export const renderDiff = async (options: DiffOptions): Promise<string> => {
     return await preloadDiffHTML({
       newFile: { contents: await readText(after, root), name: after },
       oldFile: { contents: await readText(before, root), name: before },
-      options: { theme },
+      options: { theme: diffThemes(theme) },
     });
   }
 
@@ -91,7 +126,7 @@ export const renderDiff = async (options: DiffOptions): Promise<string> => {
     return await preloadDiffHTML({
       newFile: { contents: newText, lang, name: "snippet" },
       oldFile: { contents: old, lang, name: "snippet" },
-      options: { disableFileHeader: true, theme },
+      options: { disableFileHeader: true, theme: diffThemes(theme) },
     });
   }
 

--- a/packages/blume/src/components/content/diff.ts
+++ b/packages/blume/src/components/content/diff.ts
@@ -48,20 +48,29 @@ const resolvePath = (path: string, root: string): string =>
 const readText = (path: string, root: string): Promise<string> =>
   readFile(resolvePath(path, root), "utf-8");
 
-const registeredDiffThemes = new WeakMap<object, string>();
+const registeredDiffThemes = new WeakMap<object, Map<string, string>>();
 
 /**
  * Pierre accepts custom Shiki themes through its registry, while Shiki itself
  * accepts the object directly. Register each configured object under a name
- * derived from its content so registration survives dev-server reloads: the
- * same theme re-registers under the same name (harmless overwrite), and an
- * edited theme gets a fresh name instead of a stale cached entry.
+ * derived from its content and resolved type, so registration survives
+ * dev-server reloads: the same theme re-registers under the same name (a
+ * harmless collision in Pierre's registry, which keeps the identical loader),
+ * while an edited theme gets a fresh name instead of a stale entry. The memo
+ * is keyed per resolved type as well — a typeless object shared between both
+ * modes must not hand light mode the dark-typed registration.
  */
 const diffThemeName = (theme: CodeTheme, mode: "dark" | "light"): string => {
   if (typeof theme === "string") {
     return theme;
   }
-  const cached = registeredDiffThemes.get(theme);
+  const type = theme.type ?? mode;
+  let byType = registeredDiffThemes.get(theme);
+  if (!byType) {
+    byType = new Map();
+    registeredDiffThemes.set(theme, byType);
+  }
+  const cached = byType.get(type);
   if (cached) {
     return cached;
   }
@@ -69,10 +78,10 @@ const diffThemeName = (theme: CodeTheme, mode: "dark" | "light"): string => {
     .update(JSON.stringify(theme))
     .digest("hex")
     .slice(0, 12);
-  const name = `blume-custom-${mode}-${hash}`;
-  const registered = { ...theme, name, type: theme.type ?? mode };
+  const name = `blume-custom-${hash}-${type}`;
+  const registered = { ...theme, name, type };
   registerCustomTheme(name, () => Promise.resolve(registered));
-  registeredDiffThemes.set(theme, name);
+  byType.set(type, name);
   return name;
 };
 

--- a/packages/blume/src/components/content/diff.ts
+++ b/packages/blume/src/components/content/diff.ts
@@ -49,16 +49,18 @@ const readText = (path: string, root: string): Promise<string> =>
   readFile(resolvePath(path, root), "utf-8");
 
 const registeredDiffThemes = new WeakMap<object, Map<string, string>>();
+const registeredDiffThemeNames = new Set<string>();
 
 /**
  * Pierre accepts custom Shiki themes through its registry, while Shiki itself
  * accepts the object directly. Register each configured object under a name
  * derived from its content and resolved type, so registration survives
- * dev-server reloads: the same theme re-registers under the same name (a
- * harmless collision in Pierre's registry, which keeps the identical loader),
- * while an edited theme gets a fresh name instead of a stale entry. The memo
- * is keyed per resolved type as well — a typeless object shared between both
- * modes must not hand light mode the dark-typed registration.
+ * dev-server reloads: the same theme resolves to the same name (already
+ * registered, so it's skipped — Pierre logs a console error on a same-name
+ * re-register), while an edited theme gets a fresh name instead of a stale
+ * entry. The memo is keyed per resolved type as well — a typeless object
+ * shared between both modes must not hand light mode the dark-typed
+ * registration.
  */
 const diffThemeName = (theme: CodeTheme, mode: "dark" | "light"): string => {
   if (typeof theme === "string") {
@@ -79,8 +81,11 @@ const diffThemeName = (theme: CodeTheme, mode: "dark" | "light"): string => {
     .digest("hex")
     .slice(0, 12);
   const name = `blume-custom-${hash}-${type}`;
-  const registered = { ...theme, name, type };
-  registerCustomTheme(name, () => Promise.resolve(registered));
+  if (!registeredDiffThemeNames.has(name)) {
+    const registered = { ...theme, name, type };
+    registerCustomTheme(name, () => Promise.resolve(registered));
+    registeredDiffThemeNames.add(name);
+  }
   byType.set(type, name);
   return name;
 };

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 
 import type { ComponentMarkdown } from "../ai/component-markdown.ts";
+import type { CodeTheme } from "../markdown/themes.ts";
 import type { FontSlug } from "../theme/fonts.ts";
 import type {
   blumeConfigSchema,
@@ -848,12 +849,12 @@ export interface MarkdownConfig {
    * `` `code`{:lang} ``, `<CodeBlock>`, and `<Diff>`.
    */
   codeBlocks?: {
-    /** Shiki theme names per color mode. */
+    /** Bundled Shiki theme names or inline custom Shiki themes per color mode. */
     theme?: {
-      /** Dark-mode theme. Defaults to `github-dark`. */
-      dark?: string;
-      /** Light-mode theme. Defaults to `github-light`. */
-      light?: string;
+      /** Dark-mode theme name or custom theme. Defaults to `github-dark`. */
+      dark?: CodeTheme;
+      /** Light-mode theme name or custom theme. Defaults to `github-light`. */
+      light?: CodeTheme;
     };
   };
   /**

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ComponentMarkdown } from "../ai/component-markdown.ts";
+import type { CodeTheme } from "../markdown/themes.ts";
 import { normalizeRoute } from "../openapi/references.ts";
 import { normalizeXHandle } from "../seo/x-handle.ts";
 import { FONT_SLUGS, isFontSlug } from "../theme/fonts.ts";
@@ -950,9 +951,30 @@ const githubConfigSchema = z.strictObject({
   repo: z.string(),
 });
 
+const codeThemeSchema = z.custom<CodeTheme>((value) => {
+  if (typeof value === "string") {
+    return true;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  // Token rules live in `settings` (Shiki's canonical field, also the TextMate
+  // form themes like createCssVariablesTheme() produce) or `tokenColors` (the
+  // VS Code spelling Shiki falls back to). `colors` is optional in both forms.
+  const theme = value as Record<string, unknown>;
+  const hasTokenRules =
+    Array.isArray(theme.settings) || Array.isArray(theme.tokenColors);
+  const colorsValid =
+    theme.colors === undefined ||
+    (typeof theme.colors === "object" &&
+      theme.colors !== null &&
+      !Array.isArray(theme.colors));
+  return hasTokenRules && colorsValid;
+}, "Expected a Shiki theme name or custom theme object");
+
 const codeBlockThemeSchema = z.strictObject({
-  dark: z.string().default("github-dark"),
-  light: z.string().default("github-light"),
+  dark: codeThemeSchema.default("github-dark"),
+  light: codeThemeSchema.default("github-light"),
 });
 
 const codeBlocksConfigSchema = z.strictObject({

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -960,16 +960,24 @@ const codeThemeSchema = z.custom<CodeTheme>((value) => {
   }
   // Token rules live in `settings` (Shiki's canonical field, also the TextMate
   // form themes like createCssVariablesTheme() produce) or `tokenColors` (the
-  // VS Code spelling Shiki falls back to). `colors` is optional in both forms.
+  // VS Code spelling Shiki falls back to). A colors-only theme (editor fg/bg,
+  // no token rules) is also valid — Shiki renders it from `colors` alone. Each
+  // field present must have the right shape, and at least one must be present.
   const theme = value as Record<string, unknown>;
-  const hasTokenRules =
-    Array.isArray(theme.settings) || Array.isArray(theme.tokenColors);
+  const settingsValid =
+    theme.settings === undefined || Array.isArray(theme.settings);
+  const tokenColorsValid =
+    theme.tokenColors === undefined || Array.isArray(theme.tokenColors);
   const colorsValid =
     theme.colors === undefined ||
     (typeof theme.colors === "object" &&
       theme.colors !== null &&
       !Array.isArray(theme.colors));
-  return hasTokenRules && colorsValid;
+  const hasContent =
+    theme.settings !== undefined ||
+    theme.tokenColors !== undefined ||
+    theme.colors !== undefined;
+  return settingsValid && tokenColorsValid && colorsValid && hasContent;
 }, "Expected a Shiki theme name or custom theme object");
 
 const codeBlockThemeSchema = z.strictObject({

--- a/packages/blume/src/markdown/index.ts
+++ b/packages/blume/src/markdown/index.ts
@@ -21,6 +21,8 @@ import { tableWrapPlugin } from "./table-wrap.ts";
 import { DEFAULT_CODE_THEMES } from "./themes.ts";
 import type { CodeThemes } from "./themes.ts";
 
+export type { CodeTheme, CodeThemes } from "./themes.ts";
+
 /** A Shiki transformer, derived from the upstream factories' return type. */
 type ShikiTransformer = ReturnType<typeof transformerNotationDiff>;
 

--- a/packages/blume/src/markdown/inline-code.ts
+++ b/packages/blume/src/markdown/inline-code.ts
@@ -64,7 +64,7 @@ type InlineHighlighter = (
     defaultColor: false;
     lang: string;
     structure: "inline";
-    themes: { dark: string; light: string };
+    themes: CodeThemes;
   }
 ) => Promise<{ children: HastNode[] }>;
 

--- a/packages/blume/src/markdown/themes.ts
+++ b/packages/blume/src/markdown/themes.ts
@@ -6,6 +6,11 @@
  * single home for the github fallback used when nothing is configured.
  */
 
+import type { ThemeRegistrationAny } from "shiki";
+
+/** A bundled Shiki theme name or an inline custom Shiki theme definition. */
+export type CodeTheme = string | ThemeRegistrationAny;
+
 /**
  * A light/dark Shiki theme pair (`markdown.codeBlocks.theme`). A `type` (not an
  * `interface`) so it keeps the implicit index signature Shiki's `themes`
@@ -13,8 +18,8 @@
  */
 // oxlint-disable-next-line typescript/consistent-type-definitions -- interface loses the implicit index signature Shiki's `themes` param needs
 export type CodeThemes = {
-  dark: string;
-  light: string;
+  dark: CodeTheme;
+  light: CodeTheme;
 };
 
 /** The default pair, used when `markdown.codeBlocks.theme` is unset. */

--- a/packages/blume/test/core.test.ts
+++ b/packages/blume/test/core.test.ts
@@ -243,6 +243,47 @@ describe("astro config template", () => {
     );
   });
 
+  it("preserves inline custom Shiki themes in generated config", () => {
+    const customDark = {
+      colors: {
+        "editor.background": "#010203",
+        "editor.foreground": "#fefefe",
+      },
+      name: "acme-dark",
+      tokenColors: [
+        { scope: ["keyword"], settings: { foreground: "#abcdef" } },
+      ],
+      type: "dark" as const,
+    };
+    const config = blumeConfigSchema.parse({
+      markdown: { codeBlocks: { theme: { dark: customDark } } },
+    });
+    const context = {
+      outDir: "/r/.blume",
+      pagesRoot: null,
+      root: "/r",
+    } as ProjectContext;
+
+    const output = astroConfigTemplate({
+      askPath: "/r/.blume/src/generated/Ask.astro",
+      config,
+      contentRoutes: [],
+      context,
+      dataPath: "/r/.blume/src/generated/data.json",
+      examplesPath: "/r/.blume/src/generated/examples.ts",
+      examplesThemePath: "/r/.blume/src/generated/examples.css",
+      needsReact: false,
+      openapiPath: "/r/.blume/src/generated/openapi.json",
+      pages: [],
+      searchClientPath: "/r/.blume/src/generated/search-client.ts",
+      themePath: "/r/.blume/src/generated/app.css",
+    });
+
+    expect(config.markdown.codeBlocks.theme.dark).toStrictEqual(customDark);
+    expect(output).toContain('dark: {"colors":{"editor.background":"#010203"');
+    expect(output).toContain('"codeThemes":{"dark":{"colors"');
+  });
+
   const context = {
     outDir: "/r/.blume",
     pagesRoot: null,

--- a/packages/blume/test/diff.test.ts
+++ b/packages/blume/test/diff.test.ts
@@ -94,6 +94,40 @@ describe("renderDiff", () => {
     expect(first).toContain("#040506");
   });
 
+  it("registers a typeless theme object shared by both modes once per mode", async () => {
+    // Without a per-mode memo, the light slot would reuse the dark-typed
+    // registration made first. Rendering the shared object must match
+    // rendering two independent copies, which register per mode correctly.
+    const shared = {
+      colors: {
+        "editor.background": "#070809",
+        "editor.foreground": "#fefefe",
+      },
+      name: "acme-shared",
+      tokenColors: [],
+    };
+    const options = {
+      lang: "ts",
+      new: "let value = 2;",
+      old: "const value = 1;",
+    };
+
+    const fromShared = await renderDiff({
+      ...options,
+      theme: { dark: shared, light: shared },
+    });
+    const fromCopies = await renderDiff({
+      ...options,
+      theme: {
+        dark: structuredClone(shared),
+        light: structuredClone(shared),
+      },
+    });
+
+    expect(fromShared).toBe(fromCopies);
+    expect(fromShared).toContain("#070809");
+  });
+
   it("renders with a settings-form (TextMate) custom theme", async () => {
     const html = await renderDiff({
       lang: "ts",

--- a/packages/blume/test/diff.test.ts
+++ b/packages/blume/test/diff.test.ts
@@ -39,6 +39,82 @@ describe("renderDiff", () => {
     expect(html).toContain("newInline");
   });
 
+  it("renders with inline custom Shiki themes", async () => {
+    const html = await renderDiff({
+      lang: "ts",
+      new: "let value = 2;",
+      old: "const value = 1;",
+      theme: {
+        dark: {
+          colors: {
+            "editor.background": "#010203",
+            "editor.foreground": "#fefefe",
+          },
+          name: "acme-diff-dark",
+          tokenColors: [],
+          type: "dark",
+        },
+        light: "github-light",
+      },
+    });
+
+    expect(html).toContain("#010203");
+  });
+
+  it("registers equal-content theme objects under one stable name", async () => {
+    // Distinct object instances with identical content — as produced when a
+    // dev-server reload re-evaluates the config module. The content-derived
+    // registration name makes the second render an idempotent re-register
+    // instead of a stale or duplicate entry.
+    const theme = {
+      colors: {
+        "editor.background": "#040506",
+        "editor.foreground": "#fefefe",
+      },
+      name: "acme-reload-dark",
+      tokenColors: [],
+      type: "dark" as const,
+    };
+    const options = {
+      lang: "ts",
+      new: "let value = 2;",
+      old: "const value = 1;",
+    };
+
+    const first = await renderDiff({
+      ...options,
+      theme: { dark: theme, light: "github-light" },
+    });
+    const second = await renderDiff({
+      ...options,
+      theme: { dark: structuredClone(theme), light: "github-light" },
+    });
+
+    expect(second).toBe(first);
+    expect(first).toContain("#040506");
+  });
+
+  it("renders with a settings-form (TextMate) custom theme", async () => {
+    const html = await renderDiff({
+      lang: "ts",
+      new: "let value = 2;",
+      old: "const value = 1;",
+      theme: {
+        dark: "github-dark",
+        light: {
+          name: "acme-diff-light",
+          settings: [
+            { scope: ["keyword"], settings: { foreground: "#abcdef" } },
+          ],
+          type: "light" as const,
+        },
+      },
+    });
+
+    // Shiki normalizes token colors to uppercase hex.
+    expect(html).toContain("#ABCDEF");
+  });
+
   it("renders before/after file paths (absolute)", async () => {
     const html = await renderDiff({
       after: join(root, "after.ts"),

--- a/packages/blume/test/markdown.test.ts
+++ b/packages/blume/test/markdown.test.ts
@@ -679,6 +679,30 @@ describe("inlineCodeHighlightPlugin", () => {
     expect(result?.children?.length).toBeGreaterThan(0);
   });
 
+  it("highlights inline code with an inline custom Shiki theme", async () => {
+    const custom = inlineCodeHighlightPlugin({
+      dark: {
+        colors: {
+          "editor.background": "#010203",
+          "editor.foreground": "#fefefe",
+        },
+        name: "acme-inline-dark",
+        tokenColors: [
+          { scope: ["keyword"], settings: { foreground: "#abcdef" } },
+        ],
+        type: "dark",
+      },
+      light: "github-light",
+    });
+    const result = await custom.element.visit(
+      { type: "element" },
+      inlineCtx(undefined, "const x = 1{:ts}")
+    );
+    expect(result?.tagName).toBe("code");
+    // Shiki normalizes token colors to uppercase hex.
+    expect(JSON.stringify(result?.children)).toContain("--shiki-dark:#ABCDEF");
+  });
+
   it("leaves inline code without a marker untouched", async () => {
     const result = await visit(
       { type: "element" },
@@ -898,6 +922,25 @@ describe("highlightCode", () => {
     });
 
     expect(html).toContain("--shiki-dark:#ABCDEF");
+  });
+
+  it("highlights with a colors-only custom theme", async () => {
+    // No token rules at all: Shiki styles the block from editor fg/bg.
+    const html = await highlightCode("const x = 1;", "ts", {
+      themes: {
+        dark: {
+          colors: {
+            "editor.background": "#010203",
+            "editor.foreground": "#fefefe",
+          },
+          name: "acme-colors-dark",
+          type: "dark",
+        },
+        light: "github-light",
+      },
+    });
+
+    expect(html).toContain("--shiki-dark-bg:#010203");
   });
 });
 

--- a/packages/blume/test/markdown.test.ts
+++ b/packages/blume/test/markdown.test.ts
@@ -860,6 +860,45 @@ describe("highlightCode", () => {
     // colors do), so a different dark theme must change the emitted markup.
     expect(custom).not.toBe(byDefault);
   });
+
+  it("highlights with an inline custom Shiki theme", async () => {
+    const html = await highlightCode("const x = 1;", "ts", {
+      themes: {
+        dark: {
+          colors: {
+            "editor.background": "#010203",
+            "editor.foreground": "#fefefe",
+          },
+          name: "acme-dark",
+          tokenColors: [
+            { scope: ["keyword"], settings: { foreground: "#abcdef" } },
+          ],
+          type: "dark",
+        },
+        light: "github-light",
+      },
+    });
+
+    expect(html).toContain("--shiki-dark-bg:#010203");
+    expect(html).toContain("--shiki-dark:#ABCDEF");
+  });
+
+  it("highlights with a settings-form (TextMate) custom theme", async () => {
+    const html = await highlightCode("const x = 1;", "ts", {
+      themes: {
+        dark: {
+          name: "acme-settings-dark",
+          settings: [
+            { scope: ["keyword"], settings: { foreground: "#abcdef" } },
+          ],
+          type: "dark",
+        },
+        light: "github-light",
+      },
+    });
+
+    expect(html).toContain("--shiki-dark:#ABCDEF");
+  });
 });
 
 describe("blumeTwoslashTransformer", () => {

--- a/packages/blume/test/schema-coverage.test.ts
+++ b/packages/blume/test/schema-coverage.test.ts
@@ -193,10 +193,9 @@ describe("examples config normalization", () => {
 });
 
 describe("code block themes", () => {
-  it("rejects custom themes without token rules or with malformed colors", () => {
+  it("rejects empty custom themes and malformed theme fields", () => {
     for (const theme of [
       {},
-      { colors: {} },
       { settings: {} },
       { colors: [], tokenColors: [] },
       { colors: {}, tokenColors: {} },
@@ -214,7 +213,7 @@ describe("code block themes", () => {
     }
   });
 
-  it("accepts the settings (TextMate) and tokenColors (VS Code) theme forms", () => {
+  it("accepts the settings (TextMate), tokenColors (VS Code), and colors-only theme forms", () => {
     for (const theme of [
       // The shape createCssVariablesTheme() and Shiki-normalized themes use.
       {
@@ -224,6 +223,9 @@ describe("code block themes", () => {
       },
       { tokenColors: [] },
       { colors: { "editor.background": "#010203" }, tokenColors: [] },
+      // Colors-only: no token rules — Shiki renders from editor fg/bg alone.
+      { colors: { "editor.background": "#010203" }, type: "dark" },
+      { colors: {} },
     ]) {
       const result = blumeConfigSchema.safeParse({
         markdown: { codeBlocks: { theme: { dark: theme } } },

--- a/packages/blume/test/schema-coverage.test.ts
+++ b/packages/blume/test/schema-coverage.test.ts
@@ -192,6 +192,47 @@ describe("examples config normalization", () => {
   });
 });
 
+describe("code block themes", () => {
+  it("rejects custom themes without token rules or with malformed colors", () => {
+    for (const theme of [
+      {},
+      { colors: {} },
+      { settings: {} },
+      { colors: [], tokenColors: [] },
+      { colors: {}, tokenColors: {} },
+    ]) {
+      const result = blumeConfigSchema.safeParse({
+        markdown: { codeBlocks: { theme: { dark: theme } } },
+      });
+      expect(result.success, JSON.stringify(theme)).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]).toMatchObject({
+          message: "Expected a Shiki theme name or custom theme object",
+          path: ["markdown", "codeBlocks", "theme", "dark"],
+        });
+      }
+    }
+  });
+
+  it("accepts the settings (TextMate) and tokenColors (VS Code) theme forms", () => {
+    for (const theme of [
+      // The shape createCssVariablesTheme() and Shiki-normalized themes use.
+      {
+        name: "css-variables",
+        settings: [{ scope: ["keyword"], settings: { foreground: "#abcdef" } }],
+        type: "dark",
+      },
+      { tokenColors: [] },
+      { colors: { "editor.background": "#010203" }, tokenColors: [] },
+    ]) {
+      const result = blumeConfigSchema.safeParse({
+        markdown: { codeBlocks: { theme: { dark: theme } } },
+      });
+      expect(result.success, JSON.stringify(theme)).toBe(true);
+    }
+  });
+});
+
 describe("toc heading-range refinement", () => {
   it("rejects a minHeadingLevel above the maxHeadingLevel", () => {
     const result = blumeConfigSchema.safeParse({


### PR DESCRIPTION
## Description

This adds support for custom Shiki syntax highlighting themes. The `codeThemeSchema` schema could probably be improved but this should help for now.

## Related Issues

Closes #76 

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary