### PR TITLE
Pre-bundle epub-gen-memory so the EPUB export works in dev

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Fix the EPUB page action failing in dev with `epub is not a function`. `epub-gen-memory`'s browser bundle is a browserified UMD, and its dynamic import lives inside `node_modules/blume`, which Vite's optimizer scan doesn't crawl — so in dev it was served as raw ESM, where the UMD finds no `exports`/`define`, exposes no `default`, and strands its callable on `window.epubGen`. It now joins mermaid in `optimizeDeps.include`, naming the `/bundle` subpath that is actually imported, since optimizing the package root leaves that entry unoptimized. Production builds already bundled it correctly and are unchanged.

--- a/packages/blume/src/astro/templates.ts
+++ b/packages/blume/src/astro/templates.ts
@@ -521,18 +521,25 @@ export default defineConfig({
   devToolbar: { enabled: false },
   vite: {
     plugins: [tailwindcss(), prerenderDepsPlugin(), serverAppResolvePlugin()],
-    // Mermaid (lazy-loaded client-side for diagrams) statically imports dayjs as
-    // CJS (\`dayjs/dayjs.min.js\`). In dev, an un-pre-bundled dependency is served
-    // as raw ESM, and that UMD file exposes no \`default\` export, so mermaid
-    // throws on load and diagrams render blank. Forcing mermaid through the dep
-    // optimizer bundles dayjs with correct CJS interop. In a standalone install
-    // Blume's dynamic \`import("mermaid")\` lives inside \`node_modules/blume\`,
-    // which Vite's optimizer scan doesn't crawl, so mermaid is never discovered
-    // on its own — hence the explicit include. mermaid resolves through the
-    // \`blume\` package (it isn't a direct dep of the generated project), so the
-    // nested \`blume > mermaid\` form is required. Production (Rollup) already
-    // handles the interop, so this only affects dev.
-    optimizeDeps: { include: ["blume > mermaid"] },
+    // The lazy client-side imports both land on CJS/UMD files: mermaid (for
+    // diagrams) statically imports dayjs as CJS (\`dayjs/dayjs.min.js\`), and
+    // epub-gen-memory's browser bundle is a browserified UMD. In dev, an
+    // un-pre-bundled dependency is served as raw ESM, where such a file
+    // exposes no \`default\` export — mermaid throws on load and diagrams
+    // render blank, and the EPUB export throws \`epub is not a function\`
+    // (the UMD finds no \`exports\`/\`define\` and strands its callable on
+    // \`window.epubGen\` instead). Forcing them through the dep optimizer
+    // restores the CJS interop. In a standalone install these dynamic imports
+    // live inside \`node_modules/blume\`, which Vite's optimizer scan doesn't
+    // crawl, so neither is discovered on its own — hence the explicit
+    // includes. They resolve through the \`blume\` package (they aren't direct
+    // deps of the generated project), so the nested \`blume > x\` form is
+    // required, and epub-gen-memory must name the \`/bundle\` subpath that is
+    // actually imported: optimizing the package root leaves that entry out.
+    // Production (Rollup) already handles the interop, so this only affects dev.
+    optimizeDeps: {
+      include: ["blume > mermaid", "blume > epub-gen-memory/bundle"],
+    },
     // Blume's render-time deps are forced external on both build environments so
     // native bindings resolve at runtime and isolated linkers don't bundle
     // symlinked store copies (which would surface their children as unresolvable

--- a/packages/blume/test/templates.test.ts
+++ b/packages/blume/test/templates.test.ts
@@ -617,10 +617,15 @@ describe("astroConfigTemplate", () => {
     );
     expect(out).toContain("prerenderDepsPlugin()");
     expect(out).toContain("serverAppResolvePlugin()");
-    // Mermaid is pre-bundled through the `blume` package so its CJS dayjs import
-    // gets ESM interop in dev; the nested form is required because mermaid isn't
-    // a direct dep of the generated project. See the optimizeDeps comment.
-    expect(out).toContain('optimizeDeps: { include: ["blume > mermaid"] }');
+    // Both lazy client-side deps are pre-bundled through the `blume` package so
+    // their CJS/UMD entries get ESM interop in dev; the nested form is required
+    // because neither is a direct dep of the generated project, and
+    // epub-gen-memory names the `/bundle` subpath it actually imports — the
+    // package root would leave that entry unoptimized. See the optimizeDeps
+    // comment.
+    expect(out).toContain(
+      'include: ["blume > mermaid", "blume > epub-gen-memory/bundle"]'
+    );
     // Blume's render-time deps are forced external on both build environments so
     // native bindings load at runtime and isolated linkers don't bundle (and
     // strand the children of) symlinked store copies.


### PR DESCRIPTION
## Description

The **Export to EPUB** page action throws in dev and never produces a file:

```
[blume] EPUB export failed TypeError: epub is not a function
```

Production builds are fine — this is dev-only.

### Cause

`epub-gen-memory`'s browser bundle is a browserified UMD, and Blume's `import("epub-gen-memory/bundle")` lives inside `node_modules/blume`, which Vite's optimizer scan doesn't crawl. So it's never discovered, never pre-bundled, and in dev it's served as raw ESM — where the UMD finds neither `exports` nor `define`, falls through to its global branch, and strands its callable on `window.epubGen` while exporting nothing. `epubModule.default` is `undefined`, so the `.default?.default ?? .default` unwrap can't recover it.

This is the same failure mermaid already has an `optimizeDeps.include` entry for, and the comment there notes it only affects dev.

One wrinkle: `"blume > epub-gen-memory"` alone doesn't fix it. The import targets the `/bundle` subpath, which is a separate entry from the package root, so the include has to name it — the same "subpath needs naming explicitly" point the `takumi-js/helpers` note in this file already makes for `ssr.external`.

### Verification

Measured on a real site (GitHub Pages project site, `deployment.base` set) at `blume@1.1.2`; the relevant code is unchanged on `main`. Then re-checked end to end by patching the generated config's source and letting `.blume` regenerate from scratch:

| | dev before | dev after | build |
| --- | --- | --- | --- |
| resolves to | raw `bundle.min.js` | `.vite/deps/…_bundle.js` | bundled |
| error | `epub is not a function` | none | none |
| EPUB produced | no | yes | yes (5,780 B) |
| `window.epubGen` | `object` (stranded) | `undefined` | `undefined` |

## Related Issues

None — reporting and fixing together, since the cause matched an existing in-repo pattern. Happy to split out an issue if you'd prefer.

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [ ] I've updated the docs, if necessary