### PR TITLE
Add node_modules to the .gitignore generated by blume init

### DIFF
--- a/.changeset/init-gitignore-node-modules.md
+++ b/.changeset/init-gitignore-node-modules.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+`blume init` now adds `node_modules/` to the generated `.gitignore` alongside Blume's runtime and build output directories.

--- a/packages/blume/src/cli/commands/init.ts
+++ b/packages/blume/src/cli/commands/init.ts
@@ -157,10 +157,15 @@ export const initCommand = defineCommand({
     const sink = interactive ? clack.log : logger;
     const { createdPackage } = await applyPlan(buildPlan(root, answers), sink);
 
-    // Keep Blume's generated runtime (`.blume/`) and build output (`dist/`) out
-    // of version control. Idempotent: creates `.gitignore` when absent and skips
-    // entries already present (trailing-slash agnostic).
-    const ignored = await ensureGitignore(root, [".blume/", "dist/"]);
+    // Keep installed dependencies, Blume's generated runtime (`.blume/`), and
+    // build output (`dist/`) out of version control. Idempotent: creates
+    // `.gitignore` when absent and skips entries already present
+    // (trailing-slash agnostic).
+    const ignored = await ensureGitignore(root, [
+      "node_modules/",
+      ".blume/",
+      "dist/",
+    ]);
     if (ignored.length > 0) {
       sink.success(`Added ${ignored.join(", ")} to .gitignore`);
     }

--- a/packages/blume/test/init-command.test.ts
+++ b/packages/blume/test/init-command.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+import { join } from "pathe";
+
+const CLI = join(import.meta.dir, "..", "src", "cli", "index.ts");
+
+const dirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(
+    dirs.map((dir) => rm(dir, { force: true, recursive: true }))
+  );
+});
+
+describe("blume init", () => {
+  it("ignores installed dependencies in a new project", async () => {
+    const root = await mkdtemp(join(tmpdir(), "blume-init-command-"));
+    dirs.push(root);
+    const project = join(root, "site");
+
+    // Scaffold a project through the public CLI entrypoint.
+    const proc = Bun.spawn([process.execPath, CLI, "init", project, "--yes"], {
+      cwd: root,
+      stderr: "pipe",
+      stdout: "ignore",
+    });
+    const [exitCode, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+    ]);
+
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+    expect(await readFile(join(project, ".gitignore"), "utf-8")).toBe(
+      "node_modules/\n.blume/\ndist/\n"
+    );
+  });
+});


### PR DESCRIPTION
## Description

Add `node_modules/` to the `.gitignore` generated by `blume init`, alongside `.blume/` and `dist/`.

## Related Issues

N/A

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots (if applicable)

Not applicable.

## Additional Notes

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `blume init` now adds `node_modules/` to generated `.gitignore` files alongside Blume runtime and build directories.

* **Tests**
  * Added coverage confirming successful project initialization and correct `.gitignore` entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->