### PR TITLE
Rotate a collapsible group's chevron from its own state, not an ancestor's

### DIFF
--- a/.changeset/nested-disclosure-indicators.md
+++ b/.changeset/nested-disclosure-indicators.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Fix nested `<Tree>` folder chevrons, nested `<Accordion>` chevrons, and a nested object schema's "Show properties" toggle reflecting an ancestor's open state instead of their own. All three rotated or flipped on Tailwind's `group-open:` variant, which matches any open ancestor `.group` — the same leak as the nested sidebar chevron — so a collapsed disclosure inside an expanded one showed an open indicator. Each indicator is now scoped to its own `details`.

--- a/.changeset/nested-sidebar-chevron.md
+++ b/.changeset/nested-sidebar-chevron.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Fix a nested sidebar group's chevron pointing down while the group is collapsed. The chevron rotated on Tailwind's `group-open:` variant, which matches any descendant of an open `.group` — and since every collapsible group in the tree is a `.group`, expanding a parent rotated the chevrons of its collapsed children too, so the arrow disagreed with the items it was hiding. The rotation is now scoped to the group's own `details`, leaving each chevron to reflect only its own open state.

--- a/packages/blume/src/components/content/AccordionItem.astro
+++ b/packages/blume/src/components/content/AccordionItem.astro
@@ -22,7 +22,7 @@ const accordionId = id ?? slugify(title);
 ---
 
 <details
-  class="not-prose group"
+  class="not-prose"
   data-blume-accordion
   id={accordionId}
   open={defaultOpen}
@@ -52,7 +52,7 @@ const accordionId = id ?? slugify(title);
       </span>
     </span>
     <Icon
-      class="text-muted-foreground transition-transform group-open:rotate-180"
+      class="text-muted-foreground transition-transform [details[open]>summary_&]:rotate-180"
       name="chevron-down"
       size={16}
     />

--- a/packages/blume/src/components/content/TreeFolder.astro
+++ b/packages/blume/src/components/content/TreeFolder.astro
@@ -7,7 +7,6 @@ const { defaultOpen = false, name, openable = true } = Astro.props;
 {
   openable ? (
     <details
-      class="group"
       data-blume-tree-folder
       data-blume-tree-openable="true"
       open={defaultOpen}
@@ -20,7 +19,7 @@ const { defaultOpen = false, name, openable = true } = Astro.props;
         role="treeitem"
       >
         <Icon
-          class="shrink-0 transition-transform group-open:rotate-90"
+          class="shrink-0 transition-transform [details[open]>summary_&]:rotate-90"
           name="chevron-right"
           size={15}
         />

--- a/packages/blume/src/components/layout/NavTree.astro
+++ b/packages/blume/src/components/layout/NavTree.astro
@@ -287,7 +287,11 @@ const initialId =
                       )}
                     </>
                   )}
-                  <span class="shrink-0 text-muted-foreground transition-transform group-open:rotate-90">
+                  {/* Rotate on this group's own `details`, not `group-open:`:
+                      that matches any descendant of an open `.group`, so nested
+                      groups — every one of which is a `.group` — would point
+                      down whenever an ancestor was open, while staying closed. */}
+                  <span class="shrink-0 text-muted-foreground transition-transform [details[open]>summary_&]:rotate-90">
                     <Icon name="chevron-right" size={13} />
                   </span>
                 </summary>

--- a/packages/blume/src/components/layout/NavTree.astro
+++ b/packages/blume/src/components/layout/NavTree.astro
@@ -250,7 +250,7 @@ const initialId =
           const open = active || item.collapsed === false;
           return (
             <li class={spacing}>
-              <details class="group" open={open}>
+              <details open={open}>
                 <summary class="flex cursor-pointer list-none items-center gap-1.5 rounded-[0.65rem] px-2.5 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground [&::-webkit-details-marker]:hidden">
                   {item.route ? (
                     <a
@@ -287,10 +287,10 @@ const initialId =
                       )}
                     </>
                   )}
-                  {/* Rotate on this group's own `details`, not `group-open:`:
-                      that matches any descendant of an open `.group`, so nested
-                      groups — every one of which is a `.group` — would point
-                      down whenever an ancestor was open, while staying closed. */}
+                  {/* Scope the rotation to this group's own `details` — the
+                      `group-open` variant matches any open ancestor `.group`,
+                      so nested chevrons rotated while their own group stayed
+                      closed. */}
                   <span class="shrink-0 text-muted-foreground transition-transform [details[open]>summary_&]:rotate-90">
                     <Icon name="chevron-right" size={13} />
                   </span>

--- a/packages/blume/src/components/openapi/SchemaProperty.astro
+++ b/packages/blume/src/components/openapi/SchemaProperty.astro
@@ -99,10 +99,10 @@ const expandable =
   }
   {
     expandable && (
-      <details class="group mt-2" open={expandAll}>
+      <details class="mt-2" open={expandAll}>
         <summary class="cursor-pointer select-none text-accent text-xs hover:underline">
-          <span class="group-open:hidden">Show properties</span>
-          <span class="hidden group-open:inline">Hide properties</span>
+          <span class="[details[open]>summary_&]:hidden">Show properties</span>
+          <span class="hidden [details[open]>summary_&]:inline">Hide properties</span>
         </summary>
         <div class="mt-2 border-border border-l pl-4">
           <SchemaTable

--- a/packages/blume/test/ui-coverage.test.ts
+++ b/packages/blume/test/ui-coverage.test.ts
@@ -445,6 +445,15 @@ describe("layout chrome sources", () => {
     );
   });
 
+  it("rotates a collapsible group's chevron from its own details only", async () => {
+    const source = await layoutSource("NavTree.astro");
+    // `group-open:` matches any descendant of an open `.group`, and every
+    // nested group is itself a `.group`, so a collapsed child's chevron pointed
+    // down whenever an ancestor was open.
+    expect(source).not.toContain("group-open:rotate-90");
+    expect(source).toContain("[details[open]>summary_&]:rotate-90");
+  });
+
   it("gives the reference shell lang/dir and a skip link", async () => {
     const source = await layoutSource("ReferenceLayout.astro");
     expect(source).toContain("<html dir={dir} lang={locale}>");

--- a/packages/blume/test/ui-coverage.test.ts
+++ b/packages/blume/test/ui-coverage.test.ts
@@ -394,11 +394,11 @@ describe("buildRssFeeds — pages without a date", () => {
   });
 });
 
+const componentSource = (path: string): Promise<string> =>
+  readFile(new URL(`../src/components/${path}`, import.meta.url), "utf-8");
+
 const layoutSource = (name: string): Promise<string> =>
-  readFile(
-    new URL(`../src/components/layout/${name}`, import.meta.url),
-    "utf-8"
-  );
+  componentSource(`layout/${name}`);
 
 describe("layout chrome sources", () => {
   it("toggles the search dialog on ⌘K and guards re-entrant opens", async () => {
@@ -445,13 +445,22 @@ describe("layout chrome sources", () => {
     );
   });
 
-  it("rotates a collapsible group's chevron from its own details only", async () => {
-    const source = await layoutSource("NavTree.astro");
-    // `group-open:` matches any descendant of an open `.group`, and every
-    // nested group is itself a `.group`, so a collapsed child's chevron pointed
-    // down whenever an ancestor was open.
-    expect(source).not.toContain("group-open:rotate-90");
-    expect(source).toContain("[details[open]>summary_&]:rotate-90");
+  it("rotates a collapsible disclosure's indicator from its own details only", async () => {
+    // `group-open:` matches any descendant of an open `.group`, and each of
+    // these disclosures nests inside others of the same kind (sidebar groups,
+    // tree folders, accordions in MDX, object schemas), so a collapsed child's
+    // indicator reflected an open ancestor's state instead of its own.
+    const disclosures = [
+      "layout/NavTree.astro",
+      "content/TreeFolder.astro",
+      "content/AccordionItem.astro",
+      "openapi/SchemaProperty.astro",
+    ];
+    const sources = await Promise.all(disclosures.map(componentSource));
+    for (const source of sources) {
+      expect(source).not.toContain("group-open:");
+      expect(source).toContain("[details[open]>summary_&]:");
+    }
   });
 
   it("gives the reference shell lang/dir and a skip link", async () => {


### PR DESCRIPTION
## Description

A collapsible sidebar group's chevron rotated on Tailwind's `group-open:` variant, which compiles to
a descendant selector:

```css
.group-open\:rotate-90:is(:where(.group):is([open],:popover-open,:open) *){rotate:90deg}
```

`NavTree.astro` gives every collapsible group its own `class="group"`, so a nested group's chevron is
also a descendant of each ancestor's `.group`. Expanding a parent therefore rotated the chevrons of
its collapsed children — the arrow pointed down at items it was still hiding.

This scopes the rotation to the group's own `details`:

```diff
-<span class="shrink-0 text-muted-foreground transition-transform group-open:rotate-90">
+<span class="shrink-0 text-muted-foreground transition-transform [details[open]>summary_&]:rotate-90">
```

which compiles to `details[open]>summary .…{rotate:90deg}`, so each chevron reflects only the state of
the `details` it belongs to. Nothing else about the markup or the animation changes.

## Related Issues

Closes #123

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary

## Screenshots

From a site with `navigation.sidebar.display: "group"` and category groups nested under a parent
group. In both shots the parent group is expanded, and so is its second child — the other children
are collapsed.

**Before** — every child chevron points down, including the collapsed ones:

<img width="258" height="409" alt="before" src="https://github.com/user-attachments/assets/e010fa0a-41f4-4f17-bc93-81fa87292181" />

**After** — only the expanded child points down; the collapsed siblings point right:

<img width="261" height="407" alt="after" src="https://github.com/user-attachments/assets/b52264cc-702c-4b00-857c-da6b216c2d97" />

## Additional Notes

`ui-coverage.test.ts` already asserts NavTree's classes by reading the component source, so the
regression check lives there: it pins the scoped selector and asserts the old `group-open:rotate-90`
is gone.

`group-open:` is still used elsewhere (`TypeTable.astro` via a named `group/tt`, and the
`rotate-180` chevrons in the header dropdowns) — those don't nest inside another group of the same
name, so they're unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested sidebar chevrons rotating when ancestor navigation groups are expanded.
  * Updated chevron/toggle indicators across nested disclosures so they reflect only their own expanded/collapsed state (sidebar groups, Tree folders, Accordion items, and schema “Show properties” toggles).
* **Tests**
  * Added UI coverage to ensure nested disclosure chevron rotation is properly scoped to each disclosure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->