### PR TITLE
Match nav back button radius

### DIFF
--- a/.changeset/match-nav-back-radius.md
+++ b/.changeset/match-nav-back-radius.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Match the full-width navigation back row radius to the other sidebar navigation buttons.
+Match every hoverable sidebar navigation row — the back rows, routed panel header, and flat group header — to the shared 0.65rem navigation radius.

--- a/.changeset/match-nav-back-radius.md
+++ b/.changeset/match-nav-back-radius.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Match the full-width navigation back row radius to the other sidebar navigation buttons.

--- a/packages/blume/src/components/layout/NavTree.astro
+++ b/packages/blume/src/components/layout/NavTree.astro
@@ -154,7 +154,7 @@ const initialId =
           ) : (
             <button
               aria-label={`${n.back}: ${panel.label}`}
-              class="-ml-1 mb-3 flex w-full items-center gap-1.5 rounded p-1 text-left font-semibold text-foreground text-sm transition-colors hover:bg-muted"
+              class="-ml-1 mb-3 flex w-full items-center gap-1.5 rounded-[0.65rem] p-1 text-left font-semibold text-foreground text-sm transition-colors hover:bg-muted"
               data-nav-back={panel.parentId}
               type="button"
             >

--- a/packages/blume/src/components/layout/NavTree.astro
+++ b/packages/blume/src/components/layout/NavTree.astro
@@ -137,7 +137,7 @@ const initialId =
             <div class="mb-3 flex items-center gap-0.5">
               <button
                 aria-label={n.back}
-                class="-ml-1 flex shrink-0 items-center justify-center self-stretch rounded px-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                class="-ml-1 flex shrink-0 items-center justify-center self-stretch rounded-[0.65rem] px-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 data-nav-back={panel.parentId}
                 type="button"
               >
@@ -145,7 +145,7 @@ const initialId =
               </button>
               <a
                 aria-current={panel.route === currentRoute ? "page" : undefined}
-                class="flex-1 truncate rounded px-1 py-1 font-semibold text-foreground text-sm transition-colors hover:bg-muted"
+                class="flex-1 truncate rounded-[0.65rem] px-1 py-1 font-semibold text-foreground text-sm transition-colors hover:bg-muted"
                 href={withBase(panel.route)}
               >
                 {panel.label}
@@ -317,7 +317,7 @@ const initialId =
               {item.route ? (
                 <a
                   aria-current={item.route === currentRoute ? "page" : undefined}
-                  class="-ml-1 flex flex-1 items-center gap-1.5 rounded px-1 py-0.5 text-foreground transition-colors hover:bg-muted aria-[current=page]:bg-muted"
+                  class="-ml-1 flex flex-1 items-center gap-1.5 rounded-[0.65rem] px-1 py-0.5 text-foreground transition-colors hover:bg-muted aria-[current=page]:bg-muted"
                   href={withBase(item.route)}
                 >
                   {item.icon && (

--- a/packages/blume/test/ui-coverage.test.ts
+++ b/packages/blume/test/ui-coverage.test.ts
@@ -445,6 +445,13 @@ describe("layout chrome sources", () => {
     );
   });
 
+  it("uses the sidebar row radius for the full-width NavTree back button", async () => {
+    const source = await layoutSource("NavTree.astro");
+    expect(source).toMatch(
+      /class="[^"]*w-full[^"]*rounded-\[0\.65rem\][^"]*"[\s\S]*?data-nav-back=\{panel\.parentId\}/u
+    );
+  });
+
   it("rotates a collapsible disclosure's indicator from its own details only", async () => {
     // `group-open:` matches any descendant of an open `.group`, and each of
     // these disclosures nests inside others of the same kind (sidebar groups,

--- a/packages/blume/test/ui-coverage.test.ts
+++ b/packages/blume/test/ui-coverage.test.ts
@@ -452,6 +452,17 @@ describe("layout chrome sources", () => {
     );
   });
 
+  it("never pairs the generic rounded utility with a muted row background", async () => {
+    // Every hoverable/active sidebar row shares the 0.65rem navigation radius;
+    // a bare `rounded` next to `bg-muted` renders a mismatched 4px corner.
+    const source = await layoutSource("NavTree.astro");
+    for (const match of source.matchAll(/class="[^"]*"/gu)) {
+      if (/(?:^|[\s"])rounded(?:$|[\s"])/u.test(match[0])) {
+        expect(match[0]).not.toContain("bg-muted");
+      }
+    }
+  });
+
   it("rotates a collapsible disclosure's indicator from its own details only", async () => {
     // `group-open:` matches any descendant of an open `.group`, and each of
     // these disclosures nests inside others of the same kind (sidebar groups,


### PR DESCRIPTION
## Summary

- match the full-width navigation back row to the `0.65rem` radius used by other sidebar navigation buttons
- add regression coverage for the shared sidebar-row radius

## Visual verification

Both captures use a temporary `hover:bg-white/40` background so the radius difference is easy to see. The product hover color is unchanged.

### Before

The hovered back row uses a 4px radius while the other sidebar navigation buttons use 10.4px.

<img width="280" height="56" alt="Before: hovered navigation back row with a 4px radius and white 40 percent screenshot background" src="https://github.com/user-attachments/assets/ccf88fb9-8c49-479f-a9fc-703f97ad935c" />

### After

The hovered back row now uses the same 10.4px radius as the other sidebar navigation buttons.

<img width="280" height="56" alt="After: hovered navigation back row with a 10.4px radius and white 40 percent screenshot background" src="https://github.com/user-attachments/assets/f6c99287-9800-459b-8e00-36a69311630a" />

## Root cause

The full-row click-target change used Tailwind's generic `rounded` utility instead of the sidebar's `rounded-[0.65rem]` navigation-row radius.

## Validation

- `bun test packages/blume/test/ui-coverage.test.ts`
- `bun run --filter blume typecheck`
- commit hooks: 1,980 tests passed, workspace typechecks passed, package build passed
- rendered page-mode verification in the docs app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the full-width navigation back button and related navigation rows to use a consistent `0.65rem` border radius.
* **Tests**
  * Added UI coverage assertions to ensure the navigation back button keeps the expected styling/behavior and to guard against conflicting rounded styling combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->