### PR TITLE
Style the desktop sidebar scrollbar

### DIFF
--- a/.changeset/thin-sidebar-scrollbar.md
+++ b/.changeset/thin-sidebar-scrollbar.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Style the desktop sidebar scrollbar with a thin, theme-colored thumb and a transparent track. The mobile drawer and the page scrollbar keep their platform defaults. Requires Tailwind CSS 4.3 or later, which is now the declared minimum.

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "shiki": "^4.2.0",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.3.0",
         "takumi-js": "^2.2.1",
         "turbo": "^2.3.0",
         "typescript": "^6.0.3",
@@ -54,7 +54,7 @@
     },
     "packages/blume": {
       "name": "blume",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "bin": {
         "blume": "bin/blume.mjs",
       },
@@ -102,7 +102,7 @@
         "satteri": "^0.9.5",
         "shiki": "^4.2.0",
         "simple-icons": "^13.0.0",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.3.0",
         "takumi-js": "^2.2.1",
         "tinyglobby": "^0.2.10",
         "twoslash": "^0.3.9",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "shiki": "^4.2.0",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.3.0",
     "takumi-js": "^2.2.1",
     "turbo": "^2.3.0",
     "typescript": "^6.0.3",

--- a/packages/blume/package.json
+++ b/packages/blume/package.json
@@ -109,7 +109,7 @@
     "satteri": "^0.9.5",
     "shiki": "^4.2.0",
     "simple-icons": "^13.0.0",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.3.0",
     "takumi-js": "^2.2.1",
     "tinyglobby": "^0.2.10",
     "twoslash": "^0.3.9",

--- a/packages/blume/src/components/layout/RootLayout.astro
+++ b/packages/blume/src/components/layout/RootLayout.astro
@@ -479,7 +479,7 @@ const bannerKey = banner?.dismissible ? banner.key : null;
         aria-label={navStrings.primary}
         data-blume-nav-drawer
         class:list={[
-          "fixed top-[var(--blume-drawer-top,4rem)] start-0 z-[35] h-[calc(100dvh-var(--blume-drawer-top,4rem))] w-64 max-w-[80vw] -translate-x-[105%] overflow-y-auto border-border border-e bg-background px-5 pt-4 pb-6 transition-transform rtl:translate-x-[105%] [:where([data-blume-nav-open])_&]:translate-x-0! lg:sticky lg:top-16 lg:z-auto lg:h-[calc(100dvh-4rem)] lg:w-auto lg:max-w-none lg:translate-x-0! lg:border-e-0 lg:bg-transparent lg:px-4",
+          "fixed top-[var(--blume-drawer-top,4rem)] start-0 z-[35] h-[calc(100dvh-var(--blume-drawer-top,4rem))] w-64 max-w-[80vw] -translate-x-[105%] overflow-y-auto border-border border-e bg-background px-5 pt-4 pb-6 transition-transform rtl:translate-x-[105%] [:where([data-blume-nav-open])_&]:translate-x-0! lg:sticky lg:top-16 lg:z-auto lg:h-[calc(100dvh-4rem)] lg:w-auto lg:max-w-none lg:translate-x-0! lg:scrollbar-thin lg:scrollbar-thumb-border lg:scrollbar-track-transparent lg:border-e-0 lg:bg-transparent lg:px-4",
           // A "bare" landing (the changelog index) has no sidebar column on
           // desktop, but the header hamburger still needs a drawer to open on
           // mobile — without it the toggle only locked page scroll.


### PR DESCRIPTION
## Summary

- style the desktop navigation sidebar with Tailwind's thin scrollbar utility
- use the theme border token for the thumb and a transparent track
- keep the mobile drawer's native scrollbar behavior
- intentionally leave the whole-page scrollbar at its platform default

## Screenshots

### Light mode

| Before | After |
| --- | --- |
| <img width="550" height="210" alt="Light mode before" src="https://github.com/user-attachments/assets/b11e88a2-fd84-40b7-ad75-1e1581ddade7" /> | <img width="550" height="210" alt="Light mode after" src="https://github.com/user-attachments/assets/a6c75630-0c56-4b83-aaf3-1a2a6861ee19" /> |

### Dark mode

| Before | After |
| --- | --- |
| <img width="550" height="210" alt="Dark mode before" src="https://github.com/user-attachments/assets/fe3e93a3-f012-48d1-9b4f-9493b3def34a" /> | <img width="550" height="210" alt="Dark mode after" src="https://github.com/user-attachments/assets/9d075350-d24a-4687-a2ee-599789ae0508" /> |

## Validation

- `bun run typecheck` in `packages/blume`
- `bun run build -- --isolated` in `apps/docs`
- generated CSS contains `scrollbar-width: thin` and the themed scrollbar colors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved scrollbar styling for the navigation drawer on large screens.
  * Added a thinner scrollbar with clearer thumb styling and a transparent track for a cleaner desktop experience.
* **Chores**
  * Updated the Tailwind styling tooling to a newer 4.3+ version to support the revised scrollbar styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->