### PR TITLE
Align scrollbar styles across scrollable surfaces

### DIFF
--- a/.changeset/aligned-surface-scrollbars.md
+++ b/.changeset/aligned-surface-scrollbars.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Align the table of contents, search results, search preview, and Ask AI scrollbars with the sidebar's thin scrollbar styling

--- a/packages/blume/src/components/islands/ask-ai.tsx
+++ b/packages/blume/src/components/islands/ask-ai.tsx
@@ -392,7 +392,10 @@ const AskAI = ({
         </div>
       </header>
 
-      <div className="flex flex-1 flex-col overflow-y-auto" ref={scrollRef}>
+      <div
+        className="flex flex-1 flex-col scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent overflow-y-auto"
+        ref={scrollRef}
+      >
         {hasMessages ? (
           <div className="flex flex-col gap-4 p-4">
             {messages.map((message) =>

--- a/packages/blume/src/components/layout/RootLayout.astro
+++ b/packages/blume/src/components/layout/RootLayout.astro
@@ -630,7 +630,7 @@ const bannerKey = banner?.dismissible ? banner.key : null;
         showToc && (
           <aside
             aria-label={strings.toc.title}
-            class="sticky top-16 hidden h-[calc(100dvh-4rem)] overflow-y-auto px-4 pt-6 pb-10 text-sm xl:block"
+            class="sticky top-16 hidden h-[calc(100dvh-4rem)] scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent overflow-y-auto px-4 pt-6 pb-10 text-sm xl:block"
             data-blume-toc
           >
             <TableOfContentsSlot

--- a/packages/blume/src/components/layout/Search.astro
+++ b/packages/blume/src/components/layout/Search.astro
@@ -112,7 +112,7 @@ const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
         >
         </div>
         <div
-          class="min-h-0 flex-1 overflow-y-auto p-2"
+          class="min-h-0 flex-1 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent overflow-y-auto p-2"
           data-blume-search-results
         >
         </div>
@@ -124,7 +124,7 @@ const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
         </p>
       </div>
       <div
-        class="hidden min-h-0 overflow-y-auto p-5 md:block"
+        class="hidden min-h-0 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent overflow-y-auto p-5 md:block"
         data-blume-search-preview
       >
       </div>


### PR DESCRIPTION
## Summary

- align the table of contents, search results, search preview, and Ask AI scrollbars with the Tailwind style established in the navigation sidebar
- use the same thin scrollbar, border-colored thumb, and transparent track utilities across these scrollable surfaces

## Why

The navigation sidebar introduced the shared visual direction for scrollbars. Applying that same Tailwind treatment to the other contained scroll areas makes the interface feel consistent without changing scrolling behavior.

## Validation

- `bun run typecheck` in `packages/blume`
- `bun run build -- --isolated` in `apps/docs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated scrollbars across chat, search, search preview, and table-of-contents areas with a thinner appearance and improved visual integration.
  * Preserved existing scrolling behavior, layout, spacing, and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->