### PR TITLE
feat(search): allow asset and inline SVG icons on popular links

### DIFF
--- a/.changeset/search-popular-asset-icons.md
+++ b/.changeset/search-popular-asset-icons.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Allow `search.popular` icons to use image paths/URLs and inline SVG, matching nav icons. Markup is resolved on the server before the Cmd+K island runs.

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -27,9 +27,7 @@ search: {
 },
 ```
 
-Each entry takes an `href` (internal route or external URL) and a `label`, plus an optional `icon` — a built-in icon name shown beside the label, defaulting to a file glyph. Omit `popular` or leave it empty to keep the sidebar fallback.
-
-Unlike icons elsewhere in Blume, `icon` here must be a built-in name: these rows render in a client island, so an image path or inline SVG isn't supported and falls back to the file glyph.
+Each entry takes an `href` (internal route or external URL) and a `label`, plus an optional `icon` — a [built-in icon](/docs/content/components#icon) name, image path/URL, or inline SVG (same as nav icons), defaulting to a file glyph. Omit `popular` or leave it empty to keep the sidebar fallback.
 
 Write `href` as if the site were mounted at the root — a `basePath` is applied for you, the same as `navigation.featured`. External URLs pass through untouched.
 

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -27,7 +27,7 @@ search: {
 },
 ```
 
-Each entry takes an `href` (internal route or external URL) and a `label`, plus an optional `icon` — a [built-in icon](/docs/content/components#icon) name, image path/URL, or inline SVG (same as nav icons), defaulting to a file glyph. Omit `popular` or leave it empty to keep the sidebar fallback.
+Each entry takes an `href` (internal route or external URL) and a `label`, plus an optional `icon` — a [built-in icon](/docs/content/components#icon) name, image path/URL, or inline SVG (same _inputs_ as nav icons), defaulting to a file glyph. Omit `popular` or leave it empty to keep the sidebar fallback.
 
 Write `href` as if the site were mounted at the root — a `basePath` is applied for you, the same as `navigation.featured`. External URLs pass through untouched.
 

--- a/packages/blume/src/components/Icon.astro
+++ b/packages/blume/src/components/Icon.astro
@@ -1,4 +1,5 @@
 ---
+import { isImageIcon, isInlineSvg } from "../theme/icon-kind.ts";
 import { resolveIcon } from "../theme/icons.ts";
 import { withBase } from "./islands/base-path.ts";
 
@@ -27,13 +28,7 @@ const customIcon =
     ? rawIcon
     : null;
 const iconName = typeof rawIcon === "string" ? rawIcon : null;
-const rawSvg =
-  iconName && /^\s*<svg[\s\S]*<\/svg>\s*$/u.test(iconName)
-    ? iconName.trim()
-    : null;
-const isImageIcon = (value: string): boolean =>
-  /^(?:https?:\/\/|data:image\/|\/|\.{1,2}\/)/u.test(value) ||
-  /\.(?:avif|gif|jpe?g|png|svg|webp)$/iu.test(value);
+const rawSvg = iconName && isInlineSvg(iconName) ? iconName.trim() : null;
 const imageSrc = iconName && !rawSvg && isImageIcon(iconName) ? iconName : null;
 const resolvedIcon =
   iconName && !(imageSrc || rawSvg) ? resolveIcon(iconName) : null;

--- a/packages/blume/src/components/content/Step.astro
+++ b/packages/blume/src/components/content/Step.astro
@@ -1,6 +1,7 @@
 ---
-import Icon from "../Icon.astro";
+import { isAssetIcon } from "../../theme/icon-kind.ts";
 import { hasIcon } from "../../theme/icons.ts";
+import Icon from "../Icon.astro";
 
 interface Props {
   icon?: string;
@@ -10,14 +11,8 @@ interface Props {
 const { icon, title } = Astro.props;
 const markerClass =
   "absolute top-0 -start-[2.75rem] flex size-6 items-center justify-center rounded-full bg-accent text-center font-semibold text-accent-foreground text-xs";
-const isImageIcon = (value: string): boolean =>
-  /^(?:https?:\/\/|data:image\/|\/|\.{1,2}\/)/u.test(value) ||
-  /\.(?:avif|gif|jpe?g|png|svg|webp)$/iu.test(value);
 const canRenderIcon =
-  icon !== undefined &&
-  (/^\s*<svg[\s\S]*<\/svg>\s*$/u.test(icon) ||
-    isImageIcon(icon) ||
-    hasIcon(icon));
+  icon !== undefined && (isAssetIcon(icon) || hasIcon(icon));
 ---
 
 <div

--- a/packages/blume/src/components/layout/Search.astro
+++ b/packages/blume/src/components/layout/Search.astro
@@ -2,8 +2,9 @@
 import { EN_UI } from "../../core/i18n-ui.ts";
 import type { UIStrings } from "../../core/i18n-ui.ts";
 import type { Navigation } from "../../core/types.ts";
-import { resolveIcon } from "../../theme/icons.ts";
+import { resolvePopularIconMarkup } from "../../search/popular-icon.ts";
 import Icon from "../Icon.astro";
+import { withBase } from "../islands/base-path.ts";
 import { flattenPages } from "./nav-utils.ts";
 
 // The provider-specific loader is generated per project into `blume:search-client`
@@ -28,23 +29,15 @@ const { askEnabled = false, navigation, popularPages, strings, locale } =
 // default, matching the pattern PageActions uses for its own dictionary.
 const s = { ...EN_UI.search, ...strings };
 
-// Icons resolve to inline SVG here (`theme/icons.ts` is a server-only module —
+// Icons resolve to markup here (`theme/icons.ts` is a server-only module —
 // far too large to ship to the browser), so the island gets ready-to-render
-// markup rather than a name it can't resolve. Same approach as AskAI.astro.
-// A name outside the set falls through to the island's own file glyph.
-const iconSvg = (name: string | undefined): string | undefined => {
-  const resolved = name ? resolveIcon(name) : null;
-  return resolved
-    ? `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="${resolved.viewBox}" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${resolved.body}</svg>`
-    : undefined;
-};
-
-// Pages shown in the empty state, before the user has typed anything. Only
-// curated entries carry an icon; sidebar-derived rows keep the file glyph.
+// HTML rather than a name it can't resolve. Built-in names, image paths/URLs,
+// and inline SVG all work — same shapes as nav `Icon`. Unknown names fall
+// through to the island's own file glyph.
 const popular =
   popularPages && popularPages.length > 0
     ? popularPages.map((page) => ({
-        icon: iconSvg(page.icon),
+        icon: resolvePopularIconMarkup(page.icon, withBase),
         label: page.label,
         route: page.route,
       }))
@@ -626,8 +619,8 @@ const kbd = "rounded border border-border bg-muted px-1 py-0.5 font-mono";
         const href = prefixBase(import.meta.env.BASE_URL, url);
         el.href = href;
         el.className = ROW_CLASS;
-        // `icon` is server-resolved markup from the bundled icon set, not
-        // author HTML — the label still goes through `escapeHtml`.
+        // `icon` is server-resolved markup (built-in Lucide, `<img>`, or
+        // config-authored inline SVG) — the label still goes through `escapeHtml`.
         el.innerHTML = `
           <span class="mt-0.5 shrink-0 text-muted-foreground">${icon ?? svg("file")}</span>
           <span class="flex-1">

--- a/packages/blume/src/components/layout/Search.astro
+++ b/packages/blume/src/components/layout/Search.astro
@@ -4,7 +4,6 @@ import type { UIStrings } from "../../core/i18n-ui.ts";
 import type { Navigation } from "../../core/types.ts";
 import { resolvePopularIconMarkup } from "../../search/popular-icon.ts";
 import Icon from "../Icon.astro";
-import { withBase } from "../islands/base-path.ts";
 import { flattenPages } from "./nav-utils.ts";
 
 // The provider-specific loader is generated per project into `blume:search-client`
@@ -29,15 +28,15 @@ const { askEnabled = false, navigation, popularPages, strings, locale } =
 // default, matching the pattern PageActions uses for its own dictionary.
 const s = { ...EN_UI.search, ...strings };
 
-// Icons resolve to markup here (`theme/icons.ts` is a server-only module —
-// far too large to ship to the browser), so the island gets ready-to-render
-// HTML rather than a name it can't resolve. Built-in names, image paths/URLs,
-// and inline SVG all work — same shapes as nav `Icon`. Unknown names fall
-// through to the island's own file glyph.
+// Resolve popular icons to markup here (icon set is server-only). Unknown
+// names fall through to the island's file glyph.
 const popular =
   popularPages && popularPages.length > 0
     ? popularPages.map((page) => ({
-        icon: resolvePopularIconMarkup(page.icon, withBase),
+        icon: resolvePopularIconMarkup(
+          page.icon,
+          import.meta.env.BASE_URL ?? "/"
+        ),
         label: page.label,
         route: page.route,
       }))

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -512,7 +512,10 @@ export interface MixedbreadSearch {
 export interface SearchPopularLink {
   /** Internal route or external URL. */
   href: string;
-  /** Built-in icon name shown beside the label; defaults to the file glyph. */
+  /**
+   * Icon shown beside the label — a built-in name, image path/URL, or inline
+   * SVG (same as nav icons). Defaults to the file glyph.
+   */
   icon?: string;
   /** Link label shown in the dialog. */
   label: string;

--- a/packages/blume/src/core/nav-diagnostics.ts
+++ b/packages/blume/src/core/nav-diagnostics.ts
@@ -84,10 +84,9 @@ export const validateNavIcons = (navigation: Navigation): Diagnostic[] =>
   );
 
 /**
- * Warn about unknown icons on curated `search.popular` links. Separate from
- * {@link validateNavIcons} because these live under `search`, not the built
- * navigation — and unlike nav icons they resolve in a *client* island, so only
- * set names work (an image/SVG icon quietly falls back to the file glyph).
+ * Warn about unknown icons on curated `search.popular` links. Same accepted
+ * shapes as nav icons (built-in name, image path/URL, or inline SVG) — the
+ * search dialog resolves them to markup on the server before the island runs.
  */
 export const validateSearchPopularIcons = (
   popular: { icon?: string; label: string }[]
@@ -97,25 +96,10 @@ export const validateSearchPopularIcons = (
       ? [{ icon: link.icon, where: `popular link "${link.label}"` }]
       : []
   );
-  // Asset icons are valid in the nav, so the shared helper skips them — but
-  // here they are exactly the silent failure this validator exists to catch.
-  const diagnostics: Diagnostic[] = [];
-  const seen = new Set<string>();
-  for (const { icon, where } of icons) {
-    if (isAssetIcon(icon) && !seen.has(icon)) {
-      seen.add(icon);
-      diagnostics.push({
-        code: "BLUME_UNKNOWN_ICON",
-        message: `Icon "${icon}" (${where}) is an image or inline SVG — popular links render in the client search island, where only built-in icon names resolve, so it falls back to the file glyph.`,
-        severity: "warning",
-        suggestion: "Use a built-in icon name.",
-      });
-    }
-  }
-  return [
-    ...diagnostics,
-    ...unknownIconDiagnostics(icons, "Use a built-in icon name."),
-  ];
+  return unknownIconDiagnostics(
+    icons,
+    "Use a built-in icon name, an image path/URL, or inline SVG markup."
+  );
 };
 
 /** Whether an internal path resolves to a page or a section that has pages. */

--- a/packages/blume/src/core/nav-diagnostics.ts
+++ b/packages/blume/src/core/nav-diagnostics.ts
@@ -1,3 +1,4 @@
+import { isAssetIcon } from "../theme/icon-kind.ts";
 import { hasIcon } from "../theme/icons.ts";
 import type { Diagnostic, NavNode, Navigation, PageRecord } from "./types.ts";
 
@@ -8,12 +9,8 @@ import type { Diagnostic, NavNode, Navigation, PageRecord } from "./types.ts";
  * covers every source (config, folder meta, frontmatter) at once.
  */
 
-const IMAGE_ICON =
-  /^(?:https?:\/\/|data:image\/|\/|\.{1,2}\/)|\.(?:avif|gif|jpe?g|png|svg|webp)$/iu;
-
-/** Whether an icon string is an asset (image/URL/inline SVG), not a set name. */
-const isAssetIcon = (value: string): boolean =>
-  value.startsWith("<") || IMAGE_ICON.test(value);
+const ICON_SHAPE_HINT =
+  "Use a built-in icon name, an image path/URL, or inline SVG markup.";
 
 /** Flatten a sidebar tree to every node, descending into groups. */
 const flattenNodes = (nodes: NavNode[]): NavNode[] =>
@@ -78,15 +75,11 @@ const unknownIconDiagnostics = (
 
 /** Warn about icon names that aren't in Blume's set (skipping image/SVG icons). */
 export const validateNavIcons = (navigation: Navigation): Diagnostic[] =>
-  unknownIconDiagnostics(
-    collectIcons(navigation),
-    "Use a built-in icon name, an image path/URL, or inline SVG markup."
-  );
+  unknownIconDiagnostics(collectIcons(navigation), ICON_SHAPE_HINT);
 
 /**
  * Warn about unknown icons on curated `search.popular` links. Same accepted
- * shapes as nav icons (built-in name, image path/URL, or inline SVG) — the
- * search dialog resolves them to markup on the server before the island runs.
+ * input shapes as nav icons — resolved to markup on the server for the island.
  */
 export const validateSearchPopularIcons = (
   popular: { icon?: string; label: string }[]
@@ -96,10 +89,7 @@ export const validateSearchPopularIcons = (
       ? [{ icon: link.icon, where: `popular link "${link.label}"` }]
       : []
   );
-  return unknownIconDiagnostics(
-    icons,
-    "Use a built-in icon name, an image path/URL, or inline SVG markup."
-  );
+  return unknownIconDiagnostics(icons, ICON_SHAPE_HINT);
 };
 
 /** Whether an internal path resolves to a page or a section that has pages. */

--- a/packages/blume/src/core/nav-diagnostics.ts
+++ b/packages/blume/src/core/nav-diagnostics.ts
@@ -63,9 +63,14 @@ const unknownIconDiagnostics = (
       continue;
     }
     seen.add(icon);
+    // Markup that isn't a complete <svg> element (an <img> tag, a truncated
+    // svg) is a shape problem, not a set-name typo — say so.
+    const message = icon.trimStart().startsWith("<")
+      ? `Icon markup "${icon}" (${where}) isn't a complete inline <svg> element, so it won't render.`
+      : `Unknown icon "${icon}" (${where}) — it isn't in Blume's icon set.`;
     diagnostics.push({
       code: "BLUME_UNKNOWN_ICON",
-      message: `Unknown icon "${icon}" (${where}) — it isn't in Blume's icon set.`,
+      message,
       severity: "warning",
       suggestion,
     });

--- a/packages/blume/src/search/popular-icon.ts
+++ b/packages/blume/src/search/popular-icon.ts
@@ -1,0 +1,35 @@
+import { resolveIcon } from "../theme/icons.ts";
+
+const IMAGE_ICON =
+  /^(?:https?:\/\/|data:image\/|\/|\.{1,2}\/)|\.(?:avif|gif|jpe?g|png|svg|webp)$/iu;
+
+/** Escape a value for use inside a double-quoted HTML attribute. */
+const escapeAttr = (value: string): string =>
+  value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
+
+/**
+ * Resolve a `search.popular` icon to ready-to-inject markup for the Cmd+K
+ * island. Built-in names become Lucide SVG; image paths/URLs become `<img>`;
+ * author-supplied inline `<svg>` passes through. Same shapes `Icon.astro`
+ * accepts for nav — resolved on the server so the island never loads the icon
+ * set.
+ */
+export const resolvePopularIconMarkup = (
+  icon: string | undefined,
+  withBase: (src: string) => string
+): string | undefined => {
+  if (!icon) {
+    return undefined;
+  }
+  const trimmed = icon.trim();
+  if (/^<svg[\s\S]*<\/svg>$/u.test(trimmed)) {
+    return trimmed;
+  }
+  if (IMAGE_ICON.test(trimmed)) {
+    return `<img src="${escapeAttr(withBase(trimmed))}" width="16" height="16" alt="" aria-hidden="true" class="size-4" />`;
+  }
+  const resolved = resolveIcon(trimmed);
+  return resolved
+    ? `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="${resolved.viewBox}" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${resolved.body}</svg>`
+    : undefined;
+};

--- a/packages/blume/src/search/popular-icon.ts
+++ b/packages/blume/src/search/popular-icon.ts
@@ -16,7 +16,9 @@ export const resolvePopularIconMarkup = (
     return undefined;
   }
   if (isInlineSvg(icon)) {
-    return icon.trim();
+    // Author SVG carries no guaranteed width/height (a viewBox-only <svg>
+    // defaults to 300x150), so size it the same way Icon.astro's wrapper does.
+    return `<span aria-hidden="true" style="display:inline-flex;width:16px;height:16px">${icon.trim()}</span>`;
   }
   if (isImageIcon(icon)) {
     const src = prefixBase(base, icon.trim())

--- a/packages/blume/src/search/popular-icon.ts
+++ b/packages/blume/src/search/popular-icon.ts
@@ -1,34 +1,30 @@
+import { prefixBase } from "../components/islands/base-path.ts";
+import { isImageIcon, isInlineSvg } from "../theme/icon-kind.ts";
 import { resolveIcon } from "../theme/icons.ts";
 
-const IMAGE_ICON =
-  /^(?:https?:\/\/|data:image\/|\/|\.{1,2}\/)|\.(?:avif|gif|jpe?g|png|svg|webp)$/iu;
-
-/** Escape a value for use inside a double-quoted HTML attribute. */
-const escapeAttr = (value: string): string =>
-  value.replaceAll("&", "&amp;").replaceAll('"', "&quot;");
-
 /**
- * Resolve a `search.popular` icon to ready-to-inject markup for the Cmd+K
- * island. Built-in names become Lucide SVG; image paths/URLs become `<img>`;
- * author-supplied inline `<svg>` passes through. Same shapes `Icon.astro`
- * accepts for nav — resolved on the server so the island never loads the icon
- * set.
+ * Resolve a `search.popular` icon to markup for the Cmd+K island. Accepts the
+ * same *inputs* as nav `<Icon>` (built-in name, image path/URL, inline SVG);
+ * resolved on the server so the island never loads the icon set.
  */
 export const resolvePopularIconMarkup = (
-  icon: string | undefined,
-  withBase: (src: string) => string
+  icon?: string,
+  /** `deployment.base` / `import.meta.env.BASE_URL` for root-relative image paths. */
+  base = "/"
 ): string | undefined => {
   if (!icon) {
     return undefined;
   }
-  const trimmed = icon.trim();
-  if (/^<svg[\s\S]*<\/svg>$/u.test(trimmed)) {
-    return trimmed;
+  if (isInlineSvg(icon)) {
+    return icon.trim();
   }
-  if (IMAGE_ICON.test(trimmed)) {
-    return `<img src="${escapeAttr(withBase(trimmed))}" width="16" height="16" alt="" aria-hidden="true" class="size-4" />`;
+  if (isImageIcon(icon)) {
+    const src = prefixBase(base, icon.trim())
+      .replaceAll("&", "&amp;")
+      .replaceAll('"', "&quot;");
+    return `<img src="${src}" width="16" height="16" alt="" aria-hidden="true" class="size-4" />`;
   }
-  const resolved = resolveIcon(trimmed);
+  const resolved = resolveIcon(icon);
   return resolved
     ? `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="${resolved.viewBox}" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${resolved.body}</svg>`
     : undefined;

--- a/packages/blume/src/theme/icon-kind.ts
+++ b/packages/blume/src/theme/icon-kind.ts
@@ -1,0 +1,20 @@
+/**
+ * Classify author-supplied icon strings — built-in Lucide names vs image
+ * paths/URLs vs inline SVG. Shared by nav diagnostics, `<Icon>`, and the
+ * Cmd+K popular-icon resolver so the three shapes stay in sync.
+ */
+
+const IMAGE_ICON =
+  /^(?:https?:\/\/|data:image\/|\/|\.{1,2}\/)|\.(?:avif|gif|jpe?g|png|svg|webp)$/iu;
+
+const INLINE_SVG = /^\s*<svg[\s\S]*<\/svg>\s*$/u;
+
+/** Image path, remote URL, or data URI — not a Lucide name or inline SVG. */
+export const isImageIcon = (value: string): boolean => IMAGE_ICON.test(value);
+
+/** Full `<svg>…</svg>` markup (whitespace-tolerant). */
+export const isInlineSvg = (value: string): boolean => INLINE_SVG.test(value);
+
+/** Image or inline SVG — anything that is not a built-in icon name. */
+export const isAssetIcon = (value: string): boolean =>
+  isInlineSvg(value) || isImageIcon(value);

--- a/packages/blume/test/nav-diagnostics.test.ts
+++ b/packages/blume/test/nav-diagnostics.test.ts
@@ -45,6 +45,15 @@ describe("validateSearchPopularIcons", () => {
       ])
     ).toEqual([]);
   });
+
+  it("warns on invalid markup that is not a complete inline SVG", () => {
+    const result = validateSearchPopularIcons([
+      { icon: '<img src="/logo.svg">', label: "Logo" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.code).toBe("BLUME_UNKNOWN_ICON");
+    expect(result[0]?.message).toContain('<img src="/logo.svg">');
+  });
 });
 
 describe("validateNavIcons", () => {

--- a/packages/blume/test/nav-diagnostics.test.ts
+++ b/packages/blume/test/nav-diagnostics.test.ts
@@ -36,14 +36,14 @@ describe("validateSearchPopularIcons", () => {
     ).toEqual([]);
   });
 
-  it("warns about an asset icon, which the client island cannot render", () => {
-    const result = validateSearchPopularIcons([
-      { icon: "./rocket.svg", label: "Start" },
-      { icon: "./rocket.svg", label: "Again" },
-    ]);
-    expect(result).toHaveLength(1);
-    expect(result[0]?.code).toBe("BLUME_UNKNOWN_ICON");
-    expect(result[0]?.message).toContain("file glyph");
+  it("accepts image and inline-SVG icons (resolved server-side for the island)", () => {
+    expect(
+      validateSearchPopularIcons([
+        { icon: "./rocket.svg", label: "Start" },
+        { icon: "<svg viewBox='0 0 24 24'></svg>", label: "Mark" },
+        { icon: "/logo.svg", label: "Again" },
+      ])
+    ).toEqual([]);
   });
 });
 

--- a/packages/blume/test/nav-diagnostics.test.ts
+++ b/packages/blume/test/nav-diagnostics.test.ts
@@ -53,6 +53,7 @@ describe("validateSearchPopularIcons", () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.code).toBe("BLUME_UNKNOWN_ICON");
     expect(result[0]?.message).toContain('<img src="/logo.svg">');
+    expect(result[0]?.message).toContain("isn't a complete inline <svg>");
   });
 });
 

--- a/packages/blume/test/popular-icon.test.ts
+++ b/packages/blume/test/popular-icon.test.ts
@@ -2,39 +2,33 @@ import { describe, expect, it } from "bun:test";
 
 import { resolvePopularIconMarkup } from "../src/search/popular-icon.ts";
 
-const identity = (src: string): string => src;
-const prefixDocs = (src: string): string =>
-  src.startsWith("/") ? `/docs${src}` : src;
-
 describe("resolvePopularIconMarkup", () => {
   it("returns undefined for a missing or unknown built-in name", () => {
-    expect(resolvePopularIconMarkup(undefined, identity)).toBeUndefined();
-    expect(
-      resolvePopularIconMarkup("not-a-real-icon", identity)
-    ).toBeUndefined();
+    expect(resolvePopularIconMarkup()).toBeUndefined();
+    expect(resolvePopularIconMarkup("not-a-real-icon")).toBeUndefined();
   });
 
   it("renders a built-in Lucide name as an SVG", () => {
-    const markup = resolvePopularIconMarkup("rocket", identity);
+    const markup = resolvePopularIconMarkup("rocket");
     expect(markup).toContain("<svg");
     expect(markup).toContain('width="16"');
     expect(markup).toContain('aria-hidden="true"');
   });
 
   it("passes inline SVG through", () => {
-    const svg = '<svg viewBox="0 0 24 24" class="logo-svg"></svg>';
-    expect(resolvePopularIconMarkup(svg, identity)).toBe(svg);
+    const svg = '  <svg viewBox="0 0 24 24" class="logo-svg"></svg>  ';
+    expect(resolvePopularIconMarkup(svg)).toBe(svg.trim());
   });
 
-  it("renders an image path as an img, applying withBase", () => {
-    expect(resolvePopularIconMarkup("/icons/codemap.svg", prefixDocs)).toBe(
+  it("renders an image path as an img, applying the deployment base", () => {
+    expect(resolvePopularIconMarkup("/icons/codemap.svg", "/docs")).toBe(
       '<img src="/docs/icons/codemap.svg" width="16" height="16" alt="" aria-hidden="true" class="size-4" />'
     );
   });
 
   it("escapes quotes in image src attributes", () => {
-    expect(
-      resolvePopularIconMarkup('/x"onerror="alert(1)".svg', identity)
-    ).toContain('src="/x&quot;onerror=&quot;alert(1)&quot;.svg"');
+    expect(resolvePopularIconMarkup('/x"onerror="alert(1)".svg')).toContain(
+      'src="/x&quot;onerror=&quot;alert(1)&quot;.svg"'
+    );
   });
 });

--- a/packages/blume/test/popular-icon.test.ts
+++ b/packages/blume/test/popular-icon.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolvePopularIconMarkup } from "../src/search/popular-icon.ts";
+
+const identity = (src: string): string => src;
+const prefixDocs = (src: string): string =>
+  src.startsWith("/") ? `/docs${src}` : src;
+
+describe("resolvePopularIconMarkup", () => {
+  it("returns undefined for a missing or unknown built-in name", () => {
+    expect(resolvePopularIconMarkup(undefined, identity)).toBeUndefined();
+    expect(
+      resolvePopularIconMarkup("not-a-real-icon", identity)
+    ).toBeUndefined();
+  });
+
+  it("renders a built-in Lucide name as an SVG", () => {
+    const markup = resolvePopularIconMarkup("rocket", identity);
+    expect(markup).toContain("<svg");
+    expect(markup).toContain('width="16"');
+    expect(markup).toContain('aria-hidden="true"');
+  });
+
+  it("passes inline SVG through", () => {
+    const svg = '<svg viewBox="0 0 24 24" class="logo-svg"></svg>';
+    expect(resolvePopularIconMarkup(svg, identity)).toBe(svg);
+  });
+
+  it("renders an image path as an img, applying withBase", () => {
+    expect(resolvePopularIconMarkup("/icons/codemap.svg", prefixDocs)).toBe(
+      '<img src="/docs/icons/codemap.svg" width="16" height="16" alt="" aria-hidden="true" class="size-4" />'
+    );
+  });
+
+  it("escapes quotes in image src attributes", () => {
+    expect(
+      resolvePopularIconMarkup('/x"onerror="alert(1)".svg', identity)
+    ).toContain('src="/x&quot;onerror=&quot;alert(1)&quot;.svg"');
+  });
+});

--- a/packages/blume/test/popular-icon.test.ts
+++ b/packages/blume/test/popular-icon.test.ts
@@ -20,6 +20,10 @@ describe("resolvePopularIconMarkup", () => {
     expect(resolvePopularIconMarkup(svg)).toBe(svg.trim());
   });
 
+  it("rejects non-SVG markup (falls through to the file glyph)", () => {
+    expect(resolvePopularIconMarkup('<img src="/logo.svg">')).toBeUndefined();
+  });
+
   it("renders an image path as an img, applying the deployment base", () => {
     expect(resolvePopularIconMarkup("/icons/codemap.svg", "/docs")).toBe(
       '<img src="/docs/icons/codemap.svg" width="16" height="16" alt="" aria-hidden="true" class="size-4" />'

--- a/packages/blume/test/popular-icon.test.ts
+++ b/packages/blume/test/popular-icon.test.ts
@@ -15,9 +15,11 @@ describe("resolvePopularIconMarkup", () => {
     expect(markup).toContain('aria-hidden="true"');
   });
 
-  it("passes inline SVG through", () => {
+  it("wraps inline SVG in a fixed-size span, like Icon.astro's wrapper", () => {
     const svg = '  <svg viewBox="0 0 24 24" class="logo-svg"></svg>  ';
-    expect(resolvePopularIconMarkup(svg)).toBe(svg.trim());
+    expect(resolvePopularIconMarkup(svg)).toBe(
+      `<span aria-hidden="true" style="display:inline-flex;width:16px;height:16px">${svg.trim()}</span>`
+    );
   });
 
   it("rejects non-SVG markup (falls through to the file glyph)", () => {


### PR DESCRIPTION
## Summary
- Resolve `search.popular` image paths and inline SVG to markup on the server (same shapes as nav `Icon`), so Cmd+K can show real marks instead of only Lucide names.
- Drop the diagnostic that treated assets as unsupported; update search docs + types.

Fixes #159

## Test plan
- [x] `bun test packages/blume/test/popular-icon.test.ts packages/blume/test/nav-diagnostics.test.ts`
- [x] pre-commit coverage / build
- [ ] Config `search.popular` with `/logo.svg` and an inline `<svg>` — icons render in Cmd+K empty state
- [ ] Built-in name still works; unknown name still warns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popular search links now support built-in icons, image paths or URLs, and inline SVG icons.
  * Image icons automatically respect the site’s base path.
  * Unrecognized or missing icons fall back to the default file glyph.

* **Bug Fixes**
  * Valid image and SVG icons are no longer flagged as invalid.
  * Image sources are safely escaped when rendered.

* **Documentation**
  * Updated search configuration guidance to describe the expanded icon support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->