### PR TITLE
Type-specific content definitions and filtering

### DIFF
--- a/.changeset/content-type-facets.md
+++ b/.changeset/content-type-facets.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Add declared facets: `content.types.<type>.facets` names custom frontmatter keys whose values become filterable metadata. Faceted values ride along on search documents (`blume-search.json` and the MCP snapshot), and the MCP `search_docs` and `list_pages` tools accept a `filters` object matching against them (`{"domain": "architecture", "status": "enforced"}`, every entry must match) — so a knowledge base holding RFCs, runbooks, or policies can drive progressive-disclosure agent workflows straight off its static content. Results carry their facet values, `list_pages` shows each page's, and the shared Orama index gains a `facetTerms` enum-array field so one static schema serves every project's facet keys. Each facet name must be a declared custom key (per-type or `frontmatter.extend`, validated at config load), and string, number, and boolean values facet — numbers and booleans stringified.

--- a/.changeset/mcp-content-type-filter.md
+++ b/.changeset/mcp-content-type-filter.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Let MCP clients filter by content type. `search_docs` and `list_pages` accept an optional `contentTypes` array that narrows results to pages of the given frontmatter `type`s (`["rfc"]`, `["blog", "changelog"]`), so an agent working against a site that mixes docs with RFCs, runbooks, or policies can scope retrieval to the kind of page it needs. Search hits now name their content type alongside the title, route, and excerpt, search documents carry the resolved type end to end (`blume-search.json` included), and the shared Orama index gains a `contentType` enum field filtered with an exact `where` match — the same mechanism the locale filter uses.

--- a/.changeset/per-type-frontmatter.md
+++ b/.changeset/per-type-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"blume": minor
+---
+
+Add per-type frontmatter schemas via `content.types.<type>.frontmatter`. Where `frontmatter.extend` declares custom keys site-wide, a per-type declaration scopes them to pages whose frontmatter `type` matches — so a project can require an RFC's `status` or a runbook's `service` without loosening every other page. Keys follow the same rules as `extend`: any Standard Schema library validates them (Zod at whatever version the project installs, Valibot, ArkType), every declared key is checked on every page of the type so required schemas enforce type-wide, and validated values land on the page record's `custom` field. A declaration for `content.defaultType` applies to pages that set no `type`, a key declared only for another type stays unknown elsewhere (typo-catching is unchanged), and a key can't be declared both site-wide and per-type.

--- a/apps/docs/content/docs/configuration/ai.mdx
+++ b/apps/docs/content/docs/configuration/ai.mdx
@@ -259,6 +259,18 @@ The server exposes read-only tools — `search_docs`, `get_page`, `list_pages`, 
 
 `search_docs` and `list_pages` both accept an optional `contentTypes` filter, narrowing results to pages of the given frontmatter [`type`s](/docs/reference/frontmatter) — `["rfc"]`, `["blog", "changelog"]` — so an agent working against a site that mixes docs with RFCs, runbooks, or policies can scope retrieval to the kind of page it needs. Every result names its content type, and `list_pages` output shows the types in use.
 
+Both tools also accept a `filters` object matching against the facets a site declares per content type ([`content.types.<type>.facets`](/docs/configuration#frontmatter)) — custom frontmatter keys whose values become filterable metadata:
+
+```json
+{
+  "query": "OpenAPI request schemas",
+  "contentTypes": ["rfc"],
+  "filters": { "domain": "architecture", "status": "enforced" }
+}
+```
+
+Every `filters` entry must match (results carry their facet values, and `list_pages` shows each page's), so a knowledge base can drive progressive-disclosure agent workflows — enumerate the enforced standards, search only within them — without any server of its own.
+
 ### Server output required
 
 The MCP server is a live endpoint (`/mcp`), so it can't run on a static build. Switch to server output and pick an adapter:

--- a/apps/docs/content/docs/configuration/ai.mdx
+++ b/apps/docs/content/docs/configuration/ai.mdx
@@ -257,6 +257,8 @@ The server exposes read-only tools — `search_docs`, `get_page`, `list_pages`, 
 
 `search_docs` runs its own full-text index, so it works regardless of your [search](/docs/configuration/search) provider — and even when search is set to `none`. The MCP server is a separate feature from on-page search.
 
+`search_docs` and `list_pages` both accept an optional `contentTypes` filter, narrowing results to pages of the given frontmatter [`type`s](/docs/reference/frontmatter) — `["rfc"]`, `["blog", "changelog"]` — so an agent working against a site that mixes docs with RFCs, runbooks, or policies can scope retrieval to the kind of page it needs. Every result names its content type, and `list_pages` output shows the types in use.
+
 ### Server output required
 
 The MCP server is a live endpoint (`/mcp`), so it can't run on a static build. Switch to server output and pick an adapter:

--- a/apps/docs/content/docs/configuration/index.mdx
+++ b/apps/docs/content/docs/configuration/index.mdx
@@ -241,6 +241,7 @@ export default defineConfig({
   content: {
     types: {
       rfc: {
+        facets: ["domain", "status"],
         frontmatter: {
           domain: z.string(),
           status: z.enum(["draft", "review", "enforced"]),
@@ -252,6 +253,8 @@ export default defineConfig({
 ```
 
 A key can be declared site-wide or per-type, not both. See [Per-type keys](/docs/reference/frontmatter#per-type-keys) for how the scoping resolves.
+
+`facets` names the custom keys whose values become filterable metadata: they ride along on search documents (`blume-search.json` and the MCP index), and the [MCP tools](/docs/configuration/ai#mcp-server) accept a `filters` input matching against them, so an agent can retrieve, say, only `enforced` RFCs in the `architecture` domain. Each facet must be a declared custom key — per-type or site-wide — and only string (or stringified number/boolean) values facet.
 
 ## GitHub
 

--- a/apps/docs/content/docs/configuration/index.mdx
+++ b/apps/docs/content/docs/configuration/index.mdx
@@ -189,6 +189,7 @@ content: {
 | `exclude` | `["**/_*", "**/.*"]` | Globs to ignore (underscore- and dot-files). |
 | `pages` | `"pages"` | Folder for custom `.astro` pages. |
 | `defaultType` | `"doc"` | Page `type` used when frontmatter omits it. |
+| `types` | `{}` | Per-type content definitions — custom frontmatter keys scoped to pages of one `type`. See [Frontmatter](#frontmatter). |
 
 Static assets live in `public/` — a file at `public/logo.png` is served at `/logo.png`, so a reference like `![](/images/create.png)` resolves against `public/images/create.png`. Images referenced by **relative path** (`![](./diagram.png)`) live next to your content instead, and are [optimized at build time](/docs/content/syntax#links-and-images).
 
@@ -229,6 +230,28 @@ export default defineConfig({
 ```
 
 Any [Standard Schema](https://standardschema.dev) library works — Zod (whichever version your project installs), Valibot, ArkType. Keys outside the extension stay strictly validated, so typo-catching is unchanged. See [Custom keys](/docs/reference/frontmatter#custom-keys) for the validation semantics.
+
+Keys under `extend` apply site-wide. To require keys only on pages of one content type — an RFC's `status`, a runbook's `service` — declare them per type under `content.types` instead:
+
+```ts blume.config.ts lineNumbers
+import { defineConfig } from "blume";
+import { z } from "zod";
+
+export default defineConfig({
+  content: {
+    types: {
+      rfc: {
+        frontmatter: {
+          domain: z.string(),
+          status: z.enum(["draft", "review", "enforced"]),
+        },
+      },
+    },
+  },
+});
+```
+
+A key can be declared site-wide or per-type, not both. See [Per-type keys](/docs/reference/frontmatter#per-type-keys) for how the scoping resolves.
 
 ## GitHub
 

--- a/apps/docs/content/docs/reference/frontmatter.mdx
+++ b/apps/docs/content/docs/reference/frontmatter.mdx
@@ -109,6 +109,39 @@ reviewedAt: 2026-06-20
 
 Schemas are accepted through the [Standard Schema](https://standardschema.dev) interface, so Zod (whichever version your project installs), Valibot, and ArkType all work. Every declared key is validated on every page — absent ones included — so a required schema enforces the key site-wide; mark it `.optional()` to validate only where present. All other keys stay strictly validated, and built-in fields can't be redeclared.
 
+### Per-type keys
+
+To require keys only on one content type — an RFC's `status`, an incident report's `severity` — declare them under [`content.types`](/docs/configuration#content) instead, keyed by the frontmatter `type` they apply to:
+
+```ts blume.config.ts lineNumbers
+import { defineConfig } from "blume";
+import { z } from "zod";
+
+export default defineConfig({
+  content: {
+    types: {
+      rfc: {
+        frontmatter: {
+          domain: z.string(),
+          status: z.enum(["draft", "review", "enforced"]),
+        },
+      },
+    },
+  },
+});
+```
+
+```yaml rfcs/openapi-request-schemas.mdx
+---
+title: OpenAPI request schemas
+type: rfc
+domain: architecture
+status: enforced
+---
+```
+
+Per-type keys follow the same validation rules as `extend`, scoped to pages whose resolved `type` matches — including pages that set no `type`, when the declaration is for [`content.defaultType`](/docs/configuration#content). A key belongs to one declaration, site-wide or per-type, not both. And a key declared only for another type stays unknown elsewhere, so a stray `status` on a plain doc page still fails the build.
+
 A page that fails validation fails `blume build` with a diagnostic naming the file and key. With [`--no-strict`](/docs/reference/cli#common-flags), the build succeeds anyway and the failing pages are dropped from the output — the build summary reports how many.
 
 Schemas are exported from `blume/schema` for editor and migration tooling.

--- a/packages/blume/src/ai/ask-context.ts
+++ b/packages/blume/src/ai/ask-context.ts
@@ -226,12 +226,9 @@ export const createAskContext = (
       ? byRoute.get(normalizeRoute(page.path))
       : undefined;
     const db = await index();
-    const hits = await queryOramaIndex(
-      db,
-      query,
-      MAX_RESULTS,
-      current?.locale || undefined
-    );
+    const hits = await queryOramaIndex(db, query, MAX_RESULTS, {
+      locale: current?.locale || undefined,
+    });
 
     const seen = new Set<string>();
     const sections: string[] = [];

--- a/packages/blume/src/ai/mcp/data.ts
+++ b/packages/blume/src/ai/mcp/data.ts
@@ -2,6 +2,7 @@ import { normalizeBasePath } from "../../core/base-path.ts";
 import type { BlumeProject } from "../../core/project-graph.ts";
 import type { Navigation } from "../../core/types.ts";
 import { buildSearchDocuments } from "../../search/documents.ts";
+import { pageFacets } from "../../search/facets.ts";
 import type { OramaDoc } from "../../search/orama-index.ts";
 import { agentMarkdown, buildRawMarkdown } from "../markdown.ts";
 
@@ -9,6 +10,8 @@ import { agentMarkdown, buildRawMarkdown } from "../markdown.ts";
 export interface McpRoute {
   contentType: string;
   description?: string;
+  /** Declared facet values (`content.types.<type>.facets`), key → value. */
+  facets?: Record<string, string>;
   indexable: boolean;
   lastModified: string | null;
   route: string;
@@ -67,18 +70,19 @@ export const buildMcpData = async (project: BlumeProject): Promise<McpData> => {
     ])
   );
 
-  const descriptionById = new Map(
-    graph.pages.map((page) => [page.id, page.description])
-  );
+  const pageById = new Map(graph.pages.map((page) => [page.id, page]));
 
   const routes: McpRoute[] = [];
   for (const route of manifest.routes) {
     if (route.hidden) {
       continue;
     }
+    const page = pageById.get(route.id);
+    const facets = page ? pageFacets(page, config) : undefined;
     routes.push({
       contentType: route.contentType,
-      description: descriptionById.get(route.id),
+      description: page?.description,
+      ...(facets ? { facets } : {}),
       indexable: route.indexable,
       lastModified: route.lastModified ?? null,
       route: route.path,
@@ -93,6 +97,7 @@ export const buildMcpData = async (project: BlumeProject): Promise<McpData> => {
       content: doc.content,
       contentType: doc.contentType,
       description: doc.description,
+      ...(doc.facets ? { facets: doc.facets } : {}),
       route: doc.route,
       title: doc.title,
     })),

--- a/packages/blume/src/ai/mcp/data.ts
+++ b/packages/blume/src/ai/mcp/data.ts
@@ -91,6 +91,7 @@ export const buildMcpData = async (project: BlumeProject): Promise<McpData> => {
     defaultLocale: config.i18n?.defaultLocale,
     documents: documents.map((doc) => ({
       content: doc.content,
+      contentType: doc.contentType,
       description: doc.description,
       route: doc.route,
       title: doc.title,

--- a/packages/blume/src/ai/mcp/server.ts
+++ b/packages/blume/src/ai/mcp/server.ts
@@ -41,6 +41,14 @@ const CONTENT_TYPES_SCHEMA = {
   type: "array",
 } as const;
 
+/** The optional facet filter `search_docs` and `list_pages` share. */
+const FILTERS_SCHEMA = {
+  additionalProperties: { type: "string" },
+  description:
+    'Only include pages matching every facet, key → required value (e.g. `{"status": "enforced"}`). Facets are metadata the site declares per content type; `list_pages` shows each page\'s facet values. Omit for no facet filtering.',
+  type: "object",
+} as const;
+
 /** JSON Schema for each tool's input, keyed by tool name. */
 const INPUT_SCHEMAS: Record<string, Record<string, unknown>> = {
   get_navigation: { properties: {}, type: "object" },
@@ -55,12 +63,16 @@ const INPUT_SCHEMAS: Record<string, Record<string, unknown>> = {
     type: "object",
   },
   list_pages: {
-    properties: { contentTypes: CONTENT_TYPES_SCHEMA },
+    properties: {
+      contentTypes: CONTENT_TYPES_SCHEMA,
+      filters: FILTERS_SCHEMA,
+    },
     type: "object",
   },
   search_docs: {
     properties: {
       contentTypes: CONTENT_TYPES_SCHEMA,
+      filters: FILTERS_SCHEMA,
       limit: {
         description: `Maximum hits to return (default ${DEFAULT_SEARCH_LIMIT}).`,
         maximum: MAX_SEARCH_LIMIT,
@@ -97,6 +109,27 @@ const asContentTypes = (value: unknown): string[] | undefined => {
     : [value].filter((entry): entry is string => typeof entry === "string");
   return list.length > 0 ? list : undefined;
 };
+
+/**
+ * The `filters` facet map with only its string-valued entries, or `undefined`
+ * when nothing usable remains — an empty `{}` means "no filter".
+ */
+const asFacetFilters = (value: unknown): Record<string, string> | undefined => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return;
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+/** Whether a page's facet values satisfy every requested filter entry. */
+const matchesFacets = (
+  facets: Record<string, string> | undefined,
+  filters: Record<string, string>
+): boolean =>
+  Object.entries(filters).every(([key, value]) => facets?.[key] === value);
 
 const asLimit = (value: unknown): number => {
   const num = typeof value === "number" ? value : Number(value);
@@ -206,13 +239,17 @@ export const buildServer = (
         db,
         asString(args.query),
         asLimit(args.limit),
-        { contentTypes: asContentTypes(args.contentTypes) }
+        {
+          contentTypes: asContentTypes(args.contentTypes),
+          facets: asFacetFilters(args.filters),
+        }
       );
       // `route` is the key `get_page` takes (the tool descriptions promise
       // it); `url` is where the page is served.
       const results = hits.map((doc: OramaDoc) => ({
         contentType: doc.contentType,
         excerpt: excerptFor(doc),
+        facets: doc.facets,
         route: doc.route,
         title: doc.title,
         url: urlFor(doc.route, data),
@@ -234,16 +271,18 @@ export const buildServer = (
 
     if (name === "list_pages") {
       const contentTypes = asContentTypes(args.contentTypes);
-      const routes = contentTypes
-        ? data.routes.filter((route) =>
-            contentTypes.includes(route.contentType)
-          )
-        : data.routes;
+      const filters = asFacetFilters(args.filters);
+      const routes = data.routes.filter(
+        (route) =>
+          (!contentTypes || contentTypes.includes(route.contentType)) &&
+          (!filters || matchesFacets(route.facets, filters))
+      );
       return text(
         JSON.stringify(
           routes.map((route) => ({
             contentType: route.contentType,
             description: route.description,
+            facets: route.facets,
             lastModified: route.lastModified,
             route: route.route,
             title: route.title,

--- a/packages/blume/src/ai/mcp/server.ts
+++ b/packages/blume/src/ai/mcp/server.ts
@@ -33,6 +33,14 @@ const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Expose-Headers": "Mcp-Session-Id",
 };
 
+/** The optional content-type filter `search_docs` and `list_pages` share. */
+const CONTENT_TYPES_SCHEMA = {
+  description:
+    'Only include pages of these content types (frontmatter `type`, e.g. `["doc", "rfc"]`). `list_pages` shows each page\'s type. Omit to include every type.',
+  items: { type: "string" },
+  type: "array",
+} as const;
+
 /** JSON Schema for each tool's input, keyed by tool name. */
 const INPUT_SCHEMAS: Record<string, Record<string, unknown>> = {
   get_navigation: { properties: {}, type: "object" },
@@ -46,9 +54,13 @@ const INPUT_SCHEMAS: Record<string, Record<string, unknown>> = {
     required: ["route"],
     type: "object",
   },
-  list_pages: { properties: {}, type: "object" },
+  list_pages: {
+    properties: { contentTypes: CONTENT_TYPES_SCHEMA },
+    type: "object",
+  },
   search_docs: {
     properties: {
+      contentTypes: CONTENT_TYPES_SCHEMA,
       limit: {
         description: `Maximum hits to return (default ${DEFAULT_SEARCH_LIMIT}).`,
         maximum: MAX_SEARCH_LIMIT,
@@ -73,6 +85,18 @@ const TOOL_DEFINITIONS = MCP_TOOLS.map((tool) => ({
 
 const asString = (value: unknown): string =>
   typeof value === "string" ? value : "";
+
+/**
+ * The `contentTypes` filter as a string array, or `undefined` when absent or
+ * empty — an agent sending `[]` means "no filter", not "match nothing". A bare
+ * string is accepted as a one-element list.
+ */
+const asContentTypes = (value: unknown): string[] | undefined => {
+  const list = Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [value].filter((entry): entry is string => typeof entry === "string");
+  return list.length > 0 ? list : undefined;
+};
 
 const asLimit = (value: unknown): number => {
   const num = typeof value === "number" ? value : Number(value);
@@ -181,11 +205,13 @@ export const buildServer = (
       const hits = await queryOramaIndex(
         db,
         asString(args.query),
-        asLimit(args.limit)
+        asLimit(args.limit),
+        { contentTypes: asContentTypes(args.contentTypes) }
       );
       // `route` is the key `get_page` takes (the tool descriptions promise
       // it); `url` is where the page is served.
       const results = hits.map((doc: OramaDoc) => ({
+        contentType: doc.contentType,
         excerpt: excerptFor(doc),
         route: doc.route,
         title: doc.title,
@@ -207,9 +233,15 @@ export const buildServer = (
     }
 
     if (name === "list_pages") {
+      const contentTypes = asContentTypes(args.contentTypes);
+      const routes = contentTypes
+        ? data.routes.filter((route) =>
+            contentTypes.includes(route.contentType)
+          )
+        : data.routes;
       return text(
         JSON.stringify(
-          data.routes.map((route) => ({
+          routes.map((route) => ({
             contentType: route.contentType,
             description: route.description,
             lastModified: route.lastModified,

--- a/packages/blume/src/ai/mcp/tools.ts
+++ b/packages/blume/src/ai/mcp/tools.ts
@@ -19,7 +19,7 @@ export const MCP_TOOLS: McpToolMeta[] = [
   {
     annotations: READ_ONLY,
     description:
-      "Full-text search across the documentation. Returns matching pages with their title, route, and a short excerpt. Use this first to discover relevant pages, then `get_page` to read one in full.",
+      "Full-text search across the documentation. Returns matching pages with their title, route, content type, and a short excerpt; pass `contentTypes` to search only pages of certain types (e.g. `rfc`, `changelog`). Use this first to discover relevant pages, then `get_page` to read one in full.",
     name: "search_docs",
     title: "Search documentation",
   },
@@ -33,7 +33,7 @@ export const MCP_TOOLS: McpToolMeta[] = [
   {
     annotations: READ_ONLY,
     description:
-      "List every documentation page with its route, title, description, and content type. Useful for enumerating the docs or finding a page when search is too narrow.",
+      "List every documentation page with its route, title, description, and content type; pass `contentTypes` to list only pages of certain types. Useful for enumerating the docs or finding a page when search is too narrow.",
     name: "list_pages",
     title: "List pages",
   },

--- a/packages/blume/src/ai/mcp/tools.ts
+++ b/packages/blume/src/ai/mcp/tools.ts
@@ -19,7 +19,7 @@ export const MCP_TOOLS: McpToolMeta[] = [
   {
     annotations: READ_ONLY,
     description:
-      "Full-text search across the documentation. Returns matching pages with their title, route, content type, and a short excerpt; pass `contentTypes` to search only pages of certain types (e.g. `rfc`, `changelog`). Use this first to discover relevant pages, then `get_page` to read one in full.",
+      'Full-text search across the documentation. Returns matching pages with their title, route, content type, and a short excerpt; pass `contentTypes` to search only pages of certain types (e.g. `rfc`, `changelog`), and `filters` to require facet values the site declares per type (e.g. `{"status": "enforced"}`). Use this first to discover relevant pages, then `get_page` to read one in full.',
     name: "search_docs",
     title: "Search documentation",
   },
@@ -33,7 +33,7 @@ export const MCP_TOOLS: McpToolMeta[] = [
   {
     annotations: READ_ONLY,
     description:
-      "List every documentation page with its route, title, description, and content type; pass `contentTypes` to list only pages of certain types. Useful for enumerating the docs or finding a page when search is too narrow.",
+      "List every documentation page with its route, title, description, content type, and any declared facet values; pass `contentTypes` and/or `filters` to narrow the list. Useful for enumerating the docs, discovering the types and facets in use, or finding a page when search is too narrow.",
     name: "list_pages",
     title: "List pages",
   },

--- a/packages/blume/src/components/layout/search/orama.ts
+++ b/packages/blume/src/components/layout/search/orama.ts
@@ -23,7 +23,9 @@ export const createSearch = async (opts: {
   const db = await buildOramaIndex(documents, opts.locale);
 
   return async (query, options) => {
-    const docs = await queryOramaIndex(db, query, RESULT_POOL, options?.locale);
+    const docs = await queryOramaIndex(db, query, RESULT_POOL, {
+      locale: options?.locale,
+    });
     return buildResult(docs as IndexedDocument[], query, options?.section);
   };
 };

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -297,6 +297,29 @@ export interface ContentConfig {
  */
 export interface ContentTypeConfig {
   /**
+   * Custom frontmatter keys whose values become filterable facets for pages
+   * of this type. Faceted values ride along on search documents
+   * (`blume-search.json` and the MCP index), and the MCP `search_docs` and
+   * `list_pages` tools accept a `filters` input matching against them:
+   *
+   * ```ts
+   * content: {
+   *   types: {
+   *     rfc: {
+   *       facets: ["domain", "status"],
+   *       frontmatter: { domain: z.string(), status: z.string() },
+   *     },
+   *   },
+   * },
+   * ```
+   *
+   * Each name must be a custom key declared for the type — in its
+   * `frontmatter` map or the site-wide `frontmatter.extend`. String values
+   * facet as-is; numbers and booleans are stringified; anything else
+   * (objects, arrays, transformed dates) does not facet.
+   */
+  facets?: string[];
+  /**
    * Custom frontmatter keys for pages of this type, layered on top of the
    * site-wide `frontmatter.extend` (a key can be declared in one or the
    * other, not both). Schemas follow the same rules as `extend`: any

--- a/packages/blume/src/core/config-input.ts
+++ b/packages/blume/src/core/config-input.ts
@@ -269,6 +269,44 @@ export interface ContentConfig {
    * Releases, Sanity, Notion, or a custom `ContentSource`.
    */
   sources?: ContentSourceInput[];
+  /**
+   * Per-type content definitions, keyed by the frontmatter `type` they apply
+   * to (including `defaultType`, for pages that set none):
+   *
+   * ```ts
+   * import { z } from "zod";
+   *
+   * content: {
+   *   types: {
+   *     rfc: {
+   *       frontmatter: {
+   *         domain: z.string(),
+   *         status: z.enum(["draft", "enforced"]),
+   *       },
+   *     },
+   *   },
+   * },
+   * ```
+   */
+  types?: Record<string, ContentTypeConfig>;
+}
+
+/**
+ * A per-type content definition: configuration that applies only to pages
+ * whose resolved frontmatter `type` matches the map key.
+ */
+export interface ContentTypeConfig {
+  /**
+   * Custom frontmatter keys for pages of this type, layered on top of the
+   * site-wide `frontmatter.extend` (a key can be declared in one or the
+   * other, not both). Schemas follow the same rules as `extend`: any
+   * Standard Schema library works, every declared key is validated on every
+   * page of the type — absent ones included — so a required schema enforces
+   * the key type-wide (mark it `.optional()` to validate only when present),
+   * and validated values land on the page record's `custom` field. Built-in
+   * frontmatter fields cannot be redeclared.
+   */
+  frontmatter?: Record<string, StandardSchema>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1161,7 +1199,8 @@ export interface FrontmatterConfig {
    * so a required schema enforces the key site-wide; mark it `.optional()`
    * to validate only when present. Validated values are preserved on each
    * page record's `custom` field. Built-in frontmatter fields cannot be
-   * redeclared.
+   * redeclared. To scope a key to one content type instead, declare it under
+   * `content.types.<type>.frontmatter`.
    */
   extend?: Record<string, StandardSchema>;
 }

--- a/packages/blume/src/core/project-graph.ts
+++ b/packages/blume/src/core/project-graph.ts
@@ -143,11 +143,21 @@ const normalizeLoadedEntries = (
   loaded: ({ source: ContentSource } & SourceLoadResult)[],
   config: ResolvedConfig
 ): { pages: PageRecord[]; diagnostics: Diagnostic[]; droppedPages: number } => {
-  // Only thread `frontmatter.extend` through when a project opts in, so the
-  // known-key split in `normalizeEntry` stays off the default path.
+  // Only thread `frontmatter.extend` / `content.types` through when a project
+  // opts in, so the known-key split in `normalizeEntry` stays off the default
+  // path.
   const frontmatterExtend =
     Object.keys(config.frontmatter.extend).length > 0
       ? config.frontmatter.extend
+      : undefined;
+  const declaredTypes = Object.entries(config.content.types).filter(
+    ([, type]) => Object.keys(type.frontmatter).length > 0
+  );
+  const typeFrontmatter =
+    declaredTypes.length > 0
+      ? Object.fromEntries(
+          declaredTypes.map(([name, type]) => [name, type.frontmatter])
+        )
       : undefined;
 
   const pages: PageRecord[] = [];
@@ -166,6 +176,7 @@ const normalizeLoadedEntries = (
           prefix: source.prefix,
           staged: source.staged,
         },
+        typeFrontmatter,
       });
       if (normalized.pages.length === 0 && normalized.diagnostics.length > 0) {
         droppedPages += 1;

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -141,6 +141,37 @@ export const pageMetaSchema = pageMetaBaseSchema;
 export type PageMeta = z.infer<typeof pageMetaBaseSchema>;
 export type PageMetaInput = z.input<typeof pageMetaBaseSchema>;
 
+/**
+ * A map of custom frontmatter keys to user-supplied validation schemas,
+ * consumed through the Standard Schema `~standard` contract — never Zod's own
+ * API — so the consumer's zod (any version), Valibot, or ArkType all work
+ * (see `standard-schema.ts`). Shared by the site-wide `frontmatter.extend`
+ * and the per-type `content.types.<type>.frontmatter` maps. Built-in
+ * frontmatter fields can't be redeclared — they're load-bearing (routing,
+ * sidebar, SEO), and shadowing one would silently change its semantics.
+ */
+const customKeySchemaRecord = (where: string) =>
+  z
+    .record(
+      z.string(),
+      z.custom<StandardSchema>(isStandardSchema, {
+        message:
+          "Expected a Standard Schema (e.g. a Zod schema — any Zod version works).",
+      })
+    )
+    .default({})
+    .superRefine((value, ctx) => {
+      for (const key of Object.keys(value)) {
+        if (Object.hasOwn(pageMetaBaseSchema.shape, key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `"${key}" is a built-in frontmatter field and cannot be redeclared via ${where}.`,
+            path: [key],
+          });
+        }
+      }
+    });
+
 // ---------------------------------------------------------------------------
 // Folder meta (meta.ts)
 // ---------------------------------------------------------------------------
@@ -345,6 +376,21 @@ const contentSourceSchema = z.discriminatedUnion("type", [
 /** A resolved content-source config entry (post-defaults). */
 export type ContentSourceConfig = z.infer<typeof contentSourceSchema>;
 
+/**
+ * Per-type content definition. An object (rather than a bare frontmatter map)
+ * so type-scoped concerns added later — search facets, templates — have a
+ * home without a breaking config change.
+ */
+const contentTypeConfigSchema = z.strictObject({
+  /**
+   * Custom frontmatter keys for pages of this type, layered on top of the
+   * site-wide `frontmatter.extend`. Every declared key is validated on every
+   * page of the type — absent ones included — so a required schema enforces
+   * the key type-wide while leaving other types untouched.
+   */
+  frontmatter: customKeySchemaRecord("content.types"),
+});
+
 const contentConfigSchema = z.strictObject({
   defaultType: z.string().default("doc"),
   exclude: z.array(z.string()).default(["**/_*", "**/.*"]),
@@ -357,6 +403,11 @@ const contentConfigSchema = z.strictObject({
    * existing projects are unchanged.
    */
   sources: z.array(contentSourceSchema).optional(),
+  /**
+   * Per-type content definitions, keyed by the frontmatter `type` they apply
+   * to (including `defaultType`, for pages that set none).
+   */
+  types: z.record(z.string(), contentTypeConfigSchema).default({}),
 });
 
 /**
@@ -1415,26 +1466,7 @@ const asyncapiConfigSchema = z.strictObject({
  * sidebar, SEO), and shadowing one would silently change its semantics.
  */
 const frontmatterConfigSchema = z.strictObject({
-  extend: z
-    .record(
-      z.string(),
-      z.custom<StandardSchema>(isStandardSchema, {
-        message:
-          "Expected a Standard Schema (e.g. a Zod schema — any Zod version works).",
-      })
-    )
-    .default({})
-    .superRefine((value, ctx) => {
-      for (const key of Object.keys(value)) {
-        if (Object.hasOwn(pageMetaBaseSchema.shape, key)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `"${key}" is a built-in frontmatter field and cannot be redeclared via frontmatter.extend.`,
-            path: [key],
-          });
-        }
-      }
-    }),
+  extend: customKeySchemaRecord("frontmatter.extend"),
 });
 
 /** Full user-facing config schema. All fields optional with defaults. */
@@ -1469,58 +1501,75 @@ const tocConfigSchema = z
       "toc.minHeadingLevel must be less than or equal to toc.maxHeadingLevel.",
   });
 
-export const blumeConfigSchema = z.strictObject({
-  ai: aiConfigSchema.prefault({}),
-  analytics: analyticsConfigSchema.optional(),
-  asyncapi: asyncapiConfigSchema.prefault({}),
-  banner: bannerConfigSchema.optional(),
-  /**
-   * Site-wide mount point prepended to every generated route (e.g. `/docs`),
-   * while staying invisible to the sidebar/nav tree. Distinct from a per-source
-   * `prefix` (which creates a group) and from `deployment.base` (Astro's
-   * host-subdirectory base); the two compose. Normalized to `""` or `/seg`.
-   */
-  basePath: z
-    .string()
-    .optional()
-    .transform((value) => normalizeBasePath(value)),
-  content: contentConfigSchema.prefault({}),
-  /**
-   * Date presentation for the "last updated" stamp and the changelog timeline.
-   * Pass-through `Intl.DateTimeFormat` options; defaults to `{ dateStyle: "long" }`.
-   */
-  dateFormat: dateFormatConfigSchema.default({ dateStyle: "long" }),
-  deployment: deploymentConfigSchema.prefault({}),
-  description: z.string().optional(),
-  /**
-   * Where `<Component path>` resolves live previews and their source from.
-   * A string is shorthand for `{ source }` — the directory (or glob, for
-   * colocated registry layouts) under the project root that holds example
-   * files. The object form adds `css`: a stylesheet injected into every
-   * preview frame (design tokens, shadcn variables, `@theme` mappings).
-   */
-  examples: examplesConfigSchema.prefault("examples"),
-  export: exportConfigSchema.prefault(false),
-  feedback: z.boolean().default(true),
-  /** Opt-in custom frontmatter keys, validated by user-supplied schemas. */
-  frontmatter: frontmatterConfigSchema.prefault({}),
-  github: githubConfigSchema.optional(),
-  i18n: i18nConfigSchema.optional(),
-  image: imageConfigSchema.prefault({}),
-  integrations: z.array(z.custom<AstroIntegration>()).default([]),
-  lastModified: lastModifiedConfigSchema.default(false),
-  logo: logoConfigSchema.optional(),
-  markdown: markdownConfigSchema.prefault({}),
-  navigation: navigationConfigSchema.prefault({}),
-  openapi: openapiConfigSchema.prefault({}),
-  react: reactConfigSchema.prefault({}),
-  redirects: z.array(redirectSchema).default([]),
-  search: searchConfigSchema.prefault({}),
-  seo: seoConfigSchema.prefault({}),
-  theme: themeConfigSchema.prefault({}),
-  title: z.string().default("Documentation"),
-  toc: tocConfigSchema,
-});
+export const blumeConfigSchema = z
+  .strictObject({
+    ai: aiConfigSchema.prefault({}),
+    analytics: analyticsConfigSchema.optional(),
+    asyncapi: asyncapiConfigSchema.prefault({}),
+    banner: bannerConfigSchema.optional(),
+    /**
+     * Site-wide mount point prepended to every generated route (e.g. `/docs`),
+     * while staying invisible to the sidebar/nav tree. Distinct from a per-source
+     * `prefix` (which creates a group) and from `deployment.base` (Astro's
+     * host-subdirectory base); the two compose. Normalized to `""` or `/seg`.
+     */
+    basePath: z
+      .string()
+      .optional()
+      .transform((value) => normalizeBasePath(value)),
+    content: contentConfigSchema.prefault({}),
+    /**
+     * Date presentation for the "last updated" stamp and the changelog timeline.
+     * Pass-through `Intl.DateTimeFormat` options; defaults to `{ dateStyle: "long" }`.
+     */
+    dateFormat: dateFormatConfigSchema.default({ dateStyle: "long" }),
+    deployment: deploymentConfigSchema.prefault({}),
+    description: z.string().optional(),
+    /**
+     * Where `<Component path>` resolves live previews and their source from.
+     * A string is shorthand for `{ source }` — the directory (or glob, for
+     * colocated registry layouts) under the project root that holds example
+     * files. The object form adds `css`: a stylesheet injected into every
+     * preview frame (design tokens, shadcn variables, `@theme` mappings).
+     */
+    examples: examplesConfigSchema.prefault("examples"),
+    export: exportConfigSchema.prefault(false),
+    feedback: z.boolean().default(true),
+    /** Opt-in custom frontmatter keys, validated by user-supplied schemas. */
+    frontmatter: frontmatterConfigSchema.prefault({}),
+    github: githubConfigSchema.optional(),
+    i18n: i18nConfigSchema.optional(),
+    image: imageConfigSchema.prefault({}),
+    integrations: z.array(z.custom<AstroIntegration>()).default([]),
+    lastModified: lastModifiedConfigSchema.default(false),
+    logo: logoConfigSchema.optional(),
+    markdown: markdownConfigSchema.prefault({}),
+    navigation: navigationConfigSchema.prefault({}),
+    openapi: openapiConfigSchema.prefault({}),
+    react: reactConfigSchema.prefault({}),
+    redirects: z.array(redirectSchema).default([]),
+    search: searchConfigSchema.prefault({}),
+    seo: seoConfigSchema.prefault({}),
+    theme: themeConfigSchema.prefault({}),
+    title: z.string().default("Documentation"),
+    toc: tocConfigSchema,
+  })
+  .superRefine((config, ctx) => {
+    // A custom key is declared site-wide (`frontmatter.extend`) or per-type
+    // (`content.types`), never both — two schemas for one key would make
+    // precedence on pages of that type ambiguous.
+    for (const [typeName, typeConfig] of Object.entries(config.content.types)) {
+      for (const key of Object.keys(typeConfig.frontmatter)) {
+        if (Object.hasOwn(config.frontmatter.extend, key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `"${key}" is already declared in frontmatter.extend and cannot be redeclared for type "${typeName}".`,
+            path: ["content", "types", typeName, "frontmatter", key],
+          });
+        }
+      }
+    }
+  });
 
 /** Resolved config: every field present after defaults are applied. */
 export type ResolvedConfig = z.infer<typeof blumeConfigSchema>;

--- a/packages/blume/src/core/schema.ts
+++ b/packages/blume/src/core/schema.ts
@@ -383,6 +383,15 @@ export type ContentSourceConfig = z.infer<typeof contentSourceSchema>;
  */
 const contentTypeConfigSchema = z.strictObject({
   /**
+   * Custom frontmatter keys whose values become filterable facets for pages
+   * of this type — surfaced in search documents and filterable through the
+   * MCP tools' `filters` input. Each name must be a custom key declared for
+   * the type (in its `frontmatter` map or the site-wide `frontmatter.extend`),
+   * checked at the config level where both maps are visible. Only string
+   * (or number/boolean, stringified) values ever facet.
+   */
+  facets: z.array(z.string()).default([]),
+  /**
    * Custom frontmatter keys for pages of this type, layered on top of the
    * site-wide `frontmatter.extend`. Every declared key is validated on every
    * page of the type — absent ones included — so a required schema enforces
@@ -1565,6 +1574,23 @@ export const blumeConfigSchema = z
             code: z.ZodIssueCode.custom,
             message: `"${key}" is already declared in frontmatter.extend and cannot be redeclared for type "${typeName}".`,
             path: ["content", "types", typeName, "frontmatter", key],
+          });
+        }
+      }
+      // A facet with no declared key could never carry a value — pages can't
+      // even set the key — so it's a config mistake, caught here where both
+      // the per-type map and the site-wide extend are visible.
+      for (const [position, facet] of typeConfig.facets.entries()) {
+        if (
+          !(
+            Object.hasOwn(typeConfig.frontmatter, facet) ||
+            Object.hasOwn(config.frontmatter.extend, facet)
+          )
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Facet "${facet}" for type "${typeName}" is not a declared custom frontmatter key — add it to the type's frontmatter map or frontmatter.extend.`,
+            path: ["content", "types", typeName, "facets", position],
           });
         }
       }

--- a/packages/blume/src/core/sources/normalize.ts
+++ b/packages/blume/src/core/sources/normalize.ts
@@ -516,13 +516,13 @@ const segmentKey = (
 };
 
 /**
- * Validate the opt-in custom frontmatter keys (`frontmatter.extend`) through
- * the Standard Schema contract — the consumer's own Zod (any version),
- * Valibot, or ArkType, never Blume's bundled zod (see `standard-schema.ts`).
- * Every declared key is checked, absent ones included, so a required schema
- * enforces its key on every page. Async schemas are rejected with a
- * diagnostic: this funnel is synchronous, and frontmatter validation has no
- * business awaiting I/O.
+ * Validate the opt-in custom frontmatter keys (`frontmatter.extend` and
+ * `content.types.<type>.frontmatter`) through the Standard Schema contract —
+ * the consumer's own Zod (any version), Valibot, or ArkType, never Blume's
+ * bundled zod (see `standard-schema.ts`). Every declared key is checked,
+ * absent ones included, so a required schema enforces its key on every page
+ * it applies to. Async schemas are rejected with a diagnostic: this funnel is
+ * synchronous, and frontmatter validation has no business awaiting I/O.
  */
 const validateCustomKeys = (
   data: Record<string, unknown>,
@@ -534,7 +534,7 @@ const validateCustomKeys = (
     const outcome = schema["~standard"].validate(data[key]);
     if (outcome instanceof Promise) {
       issues.push({
-        message: "Async schemas are not supported in frontmatter.extend.",
+        message: "Async schemas are not supported for custom frontmatter keys.",
         path: [key],
       });
       continue;
@@ -562,9 +562,11 @@ const validateCustomKeys = (
 
 /**
  * Parse an entry's frontmatter: built-in keys through the strict page schema,
- * custom keys (`frontmatter.extend`) through their user-supplied schemas. The
- * custom keys are carved out before the strict parse, so the page schema stays
- * strict for everything else and unknown-key typo catching is unchanged.
+ * custom keys (`frontmatter.extend` plus the page type's
+ * `content.types.<type>.frontmatter`) through their user-supplied schemas.
+ * The custom keys are carved out before the strict parse, so the page schema
+ * stays strict for everything else and unknown-key typo catching is unchanged
+ * — a key declared only for some other type stays unknown here.
  * Returns diagnostics instead of meta when either side rejects.
  */
 const parseEntryMeta = (
@@ -573,7 +575,18 @@ const parseEntryMeta = (
 ):
   | { meta: PageMeta; custom?: Record<string, unknown>; diagnostics?: never }
   | { meta?: never; diagnostics: Diagnostic[] } => {
-  const extend = ctx.frontmatterExtend;
+  // Resolved the same way `contentType` is after parsing (`meta.type` falling
+  // back to `defaultType`); a non-string `type` fails the strict parse below,
+  // so which per-type map was merged for that entry never matters.
+  const entryType =
+    typeof entry.data.type === "string" ? entry.data.type : ctx.defaultType;
+  const typeExtend = ctx.typeFrontmatter?.[entryType];
+  // Config validation rejects a key declared both site-wide and per-type, so
+  // this merge never has to pick a winner.
+  const extend =
+    ctx.frontmatterExtend || typeExtend
+      ? { ...ctx.frontmatterExtend, ...typeExtend }
+      : undefined;
   const known = extend
     ? Object.fromEntries(
         Object.entries(entry.data).filter(

--- a/packages/blume/src/core/sources/types.ts
+++ b/packages/blume/src/core/sources/types.ts
@@ -112,4 +112,9 @@ export interface NormalizeContext {
   /** Opt-in custom frontmatter keys (`frontmatter.extend`), schema per key. */
   frontmatterExtend?: FrontmatterExtend;
   i18n?: ResolvedI18nConfig;
+  /**
+   * Per-type custom frontmatter keys (`content.types.<type>.frontmatter`),
+   * applied to a page only when its resolved `type` matches.
+   */
+  typeFrontmatter?: Record<string, FrontmatterExtend>;
 }

--- a/packages/blume/src/core/types.ts
+++ b/packages/blume/src/core/types.ts
@@ -146,9 +146,10 @@ export interface PageRecord {
   contentType: string;
   meta: PageMeta;
   /**
-   * Custom frontmatter values declared via `frontmatter.extend`, validated by
-   * the user-supplied schemas (schema output, so transforms apply). Present
-   * only when the project opts in and the page carries at least one value.
+   * Custom frontmatter values declared via `frontmatter.extend` or the page
+   * type's `content.types.<type>.frontmatter`, validated by the user-supplied
+   * schemas (schema output, so transforms apply). Present only when the
+   * project opts in and the page carries at least one value.
    */
   custom?: Record<string, unknown>;
   headings: Heading[];

--- a/packages/blume/src/search/documents.ts
+++ b/packages/blume/src/search/documents.ts
@@ -5,6 +5,7 @@ import { contentIndexable } from "../core/manifest.ts";
 import type { BlumeProject } from "../core/project-graph.ts";
 import { readEntryText } from "../core/sources/read.ts";
 import type { NavNode } from "../core/types.ts";
+import { pageFacets } from "./facets.ts";
 
 /** A document indexed by the client-side search providers (Orama, FlexSearch). */
 export interface SearchDocument {
@@ -22,6 +23,11 @@ export interface SearchDocument {
   contentType: string;
   /** Frontmatter `search.tags`, surfaced for hosted-provider faceting. */
   tags?: string[];
+  /**
+   * Declared facet values (`content.types.<type>.facets`), key → value.
+   * Filterable through the MCP tools' `filters` input.
+   */
+  facets?: Record<string, string>;
 }
 
 /**
@@ -195,11 +201,13 @@ export const buildSearchDocuments = async (
         options?.content === "markdown" ? visible.trim() : toPlainText(visible);
       const tags = page?.meta?.search?.tags;
       const crumb = crumbs.get(route.path);
+      const facets = page ? pageFacets(page, project.config) : undefined;
       return {
         breadcrumb: crumb?.breadcrumb ?? [],
         content: body,
         contentType: route.contentType,
         description: page?.description ?? "",
+        ...(facets ? { facets } : {}),
         locale: route.locale,
         route: route.path,
         section: crumb?.section || "Docs",

--- a/packages/blume/src/search/documents.ts
+++ b/packages/blume/src/search/documents.ts
@@ -18,6 +18,8 @@ export interface SearchDocument {
   section: string;
   /** Locale code, so the dialog can filter results to the active language. */
   locale: string;
+  /** Resolved page `type` (`doc`, `blog`, a custom `rfc`…), for type filters. */
+  contentType: string;
   /** Frontmatter `search.tags`, surfaced for hosted-provider faceting. */
   tags?: string[];
 }
@@ -196,6 +198,7 @@ export const buildSearchDocuments = async (
       return {
         breadcrumb: crumb?.breadcrumb ?? [],
         content: body,
+        contentType: route.contentType,
         description: page?.description ?? "",
         locale: route.locale,
         route: route.path,

--- a/packages/blume/src/search/facets.ts
+++ b/packages/blume/src/search/facets.ts
@@ -1,0 +1,33 @@
+import type { ResolvedConfig } from "../core/schema.ts";
+import type { PageRecord } from "../core/types.ts";
+
+/**
+ * Resolve a page's facet values: the subset of its validated custom
+ * frontmatter named by its content type's `facets` declaration. Strings facet
+ * as-is; numbers and booleans are stringified so an enum-like `priority: 1`
+ * or `enforced: true` still filters; any other shape (objects, arrays,
+ * transformed dates) is not a facet value and is skipped. Returns `undefined`
+ * when nothing facets, so the field stays absent from serialized documents
+ * rather than shipping as `{}` on every page.
+ */
+export const pageFacets = (
+  page: Pick<PageRecord, "contentType" | "custom">,
+  config: ResolvedConfig
+): Record<string, string> | undefined => {
+  const declared = config.content.types[page.contentType]?.facets;
+  if (!declared || declared.length === 0 || !page.custom) {
+    return;
+  }
+  const facets: Record<string, string> = {};
+  for (const key of declared) {
+    const value = page.custom[key];
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      facets[key] = String(value);
+    }
+  }
+  return Object.keys(facets).length > 0 ? facets : undefined;
+};

--- a/packages/blume/src/search/orama-index.ts
+++ b/packages/blume/src/search/orama-index.ts
@@ -15,6 +15,8 @@ export interface OramaDoc {
   locale?: string;
   /** Resolved page `type`; indexed as an enum so queries can filter by type. */
   contentType?: string;
+  /** Declared facet values (`content.types.<type>.facets`), key → value. */
+  facets?: Record<string, string>;
   /** Carried through for the search dialog's breadcrumb + filter pills. Stored
    * but not indexed, so they ride along on the returned document untouched. */
   breadcrumb?: string[];
@@ -26,10 +28,18 @@ const SCHEMA = {
   // Enums (not full-text "string") so `where` does an exact-match filter.
   contentType: "enum",
   description: "string",
+  // Facets, flattened to `key:value` terms — enum[] so one static schema
+  // serves every project's facet keys, with `containsAll` matching a filter
+  // set. Derived from `facets` at insert time.
+  facetTerms: "enum[]",
   locale: "enum",
   route: "string",
   title: "string",
 } as const;
+
+/** Flatten a facet map to the `key:value` terms the `facetTerms` enum holds. */
+const toFacetTerms = (facets: Record<string, string>): string[] =>
+  Object.entries(facets).map(([key, value]) => `${key}:${value}`);
 
 /** Title and description outrank body text, matching the search dialog. */
 const BOOST = { description: 2, title: 3 };
@@ -172,7 +182,12 @@ export const buildOramaIndex = async (
     schema: SCHEMA,
     ...(tokenizer ? { components: { tokenizer } } : {}),
   });
-  await insertMultiple(db, documents);
+  await insertMultiple(
+    db,
+    documents.map((doc) =>
+      doc.facets ? { ...doc, facetTerms: toFacetTerms(doc.facets) } : doc
+    )
+  );
   return db;
 };
 
@@ -183,6 +198,11 @@ const ALL_TOKENS = 0;
 export interface OramaQueryFilters {
   /** Keep only documents whose `contentType` is in this list. */
   contentTypes?: string[];
+  /**
+   * Keep only documents matching every facet, key → required value. Facet
+   * keys and values come from the `facets` field on the indexed documents.
+   */
+  facets?: Record<string, string>;
   /** Keep only documents in this locale. */
   locale?: string;
 }
@@ -190,7 +210,8 @@ export interface OramaQueryFilters {
 /**
  * Query the index, returning the matching documents (highest-ranked first).
  * `filters` narrows results by exact `where` matches on the enum fields:
- * `locale` to one language, `contentTypes` to a set of page types.
+ * `locale` to one language, `contentTypes` to a set of page types, `facets`
+ * to documents carrying every requested `key:value` term.
  *
  * On a bigrammed index the strict pass runs first: a term is only meant to
  * match where its bigrams sit together, and scoring them independently lets a
@@ -204,10 +225,14 @@ export const queryOramaIndex = async (
   limit: number,
   filters?: OramaQueryFilters
 ): Promise<OramaDoc[]> => {
+  const facetTerms = filters?.facets ? toFacetTerms(filters.facets) : [];
   const where = {
     ...(filters?.locale ? { locale: { eq: filters.locale } } : {}),
     ...(filters?.contentTypes && filters.contentTypes.length > 0
       ? { contentType: { in: filters.contentTypes } }
+      : {}),
+    ...(facetTerms.length > 0
+      ? { facetTerms: { containsAll: facetTerms } }
       : {}),
   };
   const params = {

--- a/packages/blume/src/search/orama-index.ts
+++ b/packages/blume/src/search/orama-index.ts
@@ -13,6 +13,8 @@ export interface OramaDoc {
   title: string;
   /** Locale code; indexed as an enum so queries can filter to one language. */
   locale?: string;
+  /** Resolved page `type`; indexed as an enum so queries can filter by type. */
+  contentType?: string;
   /** Carried through for the search dialog's breadcrumb + filter pills. Stored
    * but not indexed, so they ride along on the returned document untouched. */
   breadcrumb?: string[];
@@ -21,8 +23,9 @@ export interface OramaDoc {
 
 const SCHEMA = {
   content: "string",
+  // Enums (not full-text "string") so `where` does an exact-match filter.
+  contentType: "enum",
   description: "string",
-  // Enum (not full-text "string") so `where` does an exact-match filter.
   locale: "enum",
   route: "string",
   title: "string",
@@ -176,10 +179,18 @@ export const buildOramaIndex = async (
 /** Orama keeps only documents matching every token at a threshold of 0. */
 const ALL_TOKENS = 0;
 
+/** Optional exact-match filters applied to a query via Orama's `where`. */
+export interface OramaQueryFilters {
+  /** Keep only documents whose `contentType` is in this list. */
+  contentTypes?: string[];
+  /** Keep only documents in this locale. */
+  locale?: string;
+}
+
 /**
  * Query the index, returning the matching documents (highest-ranked first).
- * When `locale` is given, results are filtered to that language via an exact
- * `where` match on the `locale` enum.
+ * `filters` narrows results by exact `where` matches on the enum fields:
+ * `locale` to one language, `contentTypes` to a set of page types.
  *
  * On a bigrammed index the strict pass runs first: a term is only meant to
  * match where its bigrams sit together, and scoring them independently lets a
@@ -191,14 +202,20 @@ export const queryOramaIndex = async (
   db: AnyOrama,
   term: string,
   limit: number,
-  locale?: string
+  filters?: OramaQueryFilters
 ): Promise<OramaDoc[]> => {
+  const where = {
+    ...(filters?.locale ? { locale: { eq: filters.locale } } : {}),
+    ...(filters?.contentTypes && filters.contentTypes.length > 0
+      ? { contentType: { in: filters.contentTypes } }
+      : {}),
+  };
   const params = {
     boost: BOOST,
     limit,
     properties: ["title", "description", "content"],
     term,
-    ...(locale ? { where: { locale: { eq: locale } } } : {}),
+    ...(Object.keys(where).length > 0 ? { where } : {}),
   };
   const bigrammed = BIGRAM_LANGUAGES.has(db.tokenizer?.language ?? "");
   const strict = bigrammed

--- a/packages/blume/test/config.test.ts
+++ b/packages/blume/test/config.test.ts
@@ -195,6 +195,33 @@ export default { content: { types: { rfc: { frontmatter: { title: owner } } } } 
     expect(error.diagnostic.message).toContain("built-in frontmatter field");
   });
 
+  it("accepts facets naming declared per-type or site-wide keys", async () => {
+    const dir = await makeDir(
+      `${OWNER_SCHEMA}
+export default {
+  content: { types: { rfc: { facets: ["status", "owner"], frontmatter: { status: owner } } } },
+  frontmatter: { extend: { owner } },
+};`
+    );
+    const result = await loadConfig(dir);
+    expect(result.config.content.types.rfc?.facets).toStrictEqual([
+      "status",
+      "owner",
+    ]);
+  });
+
+  it("rejects a facet that is not a declared custom key", async () => {
+    const dir = await makeDir(
+      `${OWNER_SCHEMA}
+export default { content: { types: { rfc: { facets: ["status"], frontmatter: { owner } } } } };`
+    );
+    const error = await loadError(dir);
+    expect(error.diagnostic.code).toBe("BLUME_CONFIG_INVALID");
+    expect(error.diagnostic.message).toContain(
+      "not a declared custom frontmatter key"
+    );
+  });
+
   it("rejects a key declared in both frontmatter.extend and a content type", async () => {
     const dir = await makeDir(
       `${OWNER_SCHEMA}

--- a/packages/blume/test/config.test.ts
+++ b/packages/blume/test/config.test.ts
@@ -174,6 +174,42 @@ export default { frontmatter: { extend: { title: owner } } };`
     expect(error.diagnostic.message).toContain("built-in frontmatter field");
   });
 
+  it("accepts per-type frontmatter schemas under content.types", async () => {
+    const dir = await makeDir(
+      `${OWNER_SCHEMA}
+export default { content: { types: { rfc: { frontmatter: { owner } } } } };`
+    );
+    const result = await loadConfig(dir);
+    expect(
+      Object.keys(result.config.content.types.rfc?.frontmatter ?? {})
+    ).toStrictEqual(["owner"]);
+  });
+
+  it("rejects redeclaring a built-in frontmatter field via content.types", async () => {
+    const dir = await makeDir(
+      `${OWNER_SCHEMA}
+export default { content: { types: { rfc: { frontmatter: { title: owner } } } } };`
+    );
+    const error = await loadError(dir);
+    expect(error.diagnostic.code).toBe("BLUME_CONFIG_INVALID");
+    expect(error.diagnostic.message).toContain("built-in frontmatter field");
+  });
+
+  it("rejects a key declared in both frontmatter.extend and a content type", async () => {
+    const dir = await makeDir(
+      `${OWNER_SCHEMA}
+export default {
+  content: { types: { rfc: { frontmatter: { owner } } } },
+  frontmatter: { extend: { owner } },
+};`
+    );
+    const error = await loadError(dir);
+    expect(error.diagnostic.code).toBe("BLUME_CONFIG_INVALID");
+    expect(error.diagnostic.message).toContain(
+      "already declared in frontmatter.extend"
+    );
+  });
+
   it("throws a BlumeError when the config module fails to load", async () => {
     const dir = await makeDir('throw new Error("boom");');
     const error = await loadError(dir);

--- a/packages/blume/test/mcp.test.ts
+++ b/packages/blume/test/mcp.test.ts
@@ -233,6 +233,92 @@ describe("MCP tools", () => {
       "/guides/install",
     ]);
   });
+});
+
+describe("MCP content-type filtering", () => {
+  const TYPED: McpData = {
+    ...DATA,
+    documents: [
+      ...DATA.documents.map((doc) => ({ ...doc, contentType: "doc" })),
+      {
+        content: "RFC: how Blume endpoints declare request schemas.",
+        contentType: "rfc",
+        description: "RFC for request validation",
+        route: "/rfcs/schemas",
+        title: "Request schemas",
+      },
+    ],
+    routes: [
+      ...DATA.routes,
+      {
+        contentType: "rfc",
+        description: "RFC for request validation",
+        indexable: true,
+        lastModified: null,
+        route: "/rfcs/schemas",
+        title: "Request schemas",
+      },
+    ],
+  };
+  const typedHandler = createMcpFetchHandler(TYPED);
+
+  const callTyped = async (name: string, args?: Record<string, unknown>) => {
+    const response = await typedHandler(
+      new Request("https://docs.example.com/mcp", {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { arguments: args, name },
+        }),
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      })
+    );
+    const body = (await response.json()) as {
+      result?: { content?: { text: string }[] };
+    };
+    return body.result?.content?.[0]?.text ?? "";
+  };
+
+  it("search_docs filters hits to the requested content types", async () => {
+    const rfcs = JSON.parse(
+      await callTyped("search_docs", { contentTypes: ["rfc"], query: "blume" })
+    ) as { contentType: string; route: string }[];
+    expect(rfcs.map((hit) => hit.route)).toEqual(["/rfcs/schemas"]);
+    // Hits name their type, so an agent can see what it got back.
+    expect(rfcs[0]?.contentType).toBe("rfc");
+
+    const docs = JSON.parse(
+      await callTyped("search_docs", { contentTypes: ["doc"], query: "blume" })
+    ) as { route: string }[];
+    expect(docs.map((hit) => hit.route).toSorted()).toEqual([
+      "/guides/config",
+      "/guides/install",
+    ]);
+  });
+
+  it("search_docs treats an empty or absent contentTypes as no filter", async () => {
+    const unfiltered = JSON.parse(
+      await callTyped("search_docs", { contentTypes: [], query: "blume" })
+    ) as unknown[];
+    expect(unfiltered.length).toBe(3);
+  });
+
+  it("list_pages filters routes by content type", async () => {
+    const rfcs = JSON.parse(
+      await callTyped("list_pages", { contentTypes: ["rfc"] })
+    ) as { route: string }[];
+    expect(rfcs.map((page) => page.route)).toEqual(["/rfcs/schemas"]);
+
+    const all = JSON.parse(
+      await callTyped("list_pages", { contentTypes: ["doc", "rfc"] })
+    ) as unknown[];
+    expect(all.length).toBe(3);
+  });
 
   it("get_navigation returns the navigation tree", async () => {
     const { text } = await callTool("get_navigation");
@@ -420,11 +506,51 @@ describe("orama index helpers", () => {
         title: "Installation",
       },
     ]);
-    const fr = await queryOramaIndex(db, "install", 5, "fr");
+    const fr = await queryOramaIndex(db, "install", 5, { locale: "fr" });
     expect(fr.map((doc) => doc.route)).toEqual(["/fr/install"]);
     // No filter searches every language.
     const all = await queryOramaIndex(db, "install", 5);
     expect(all.length).toBe(2);
+  });
+
+  it("filters results to the requested content types", async () => {
+    const db = await buildOramaIndex([
+      {
+        content: "Install Blume with your package manager.",
+        contentType: "doc",
+        description: "",
+        route: "/install",
+        title: "Install",
+      },
+      {
+        content: "RFC: how Blume endpoints declare request schemas.",
+        contentType: "rfc",
+        description: "",
+        route: "/rfcs/schemas",
+        title: "Request schemas",
+      },
+      {
+        // No contentType (a pre-upgrade index entry): excluded by any filter.
+        content: "Blume changelog for the current release.",
+        description: "",
+        route: "/changelog",
+        title: "Changelog",
+      },
+    ]);
+    const rfcs = await queryOramaIndex(db, "blume", 5, {
+      contentTypes: ["rfc"],
+    });
+    expect(rfcs.map((doc) => doc.route)).toEqual(["/rfcs/schemas"]);
+    const both = await queryOramaIndex(db, "blume", 5, {
+      contentTypes: ["doc", "rfc"],
+    });
+    expect(both.map((doc) => doc.route).toSorted()).toEqual([
+      "/install",
+      "/rfcs/schemas",
+    ]);
+    // An empty list means "no filter", matching the MCP tool contract.
+    const all = await queryOramaIndex(db, "blume", 5, { contentTypes: [] });
+    expect(all.length).toBe(3);
   });
 
   const JA_DOCS = [
@@ -470,7 +596,7 @@ describe("orama index helpers", () => {
     const gdpr = await queryOramaIndex(db, "gdpr", 5);
     expect(gdpr.map((doc) => doc.route)).toEqual(["/ja/legal"]);
     // The locale enum filter is unaffected by the custom tokenizer.
-    const en = await queryOramaIndex(db, "install", 5, "en");
+    const en = await queryOramaIndex(db, "install", 5, { locale: "en" });
     expect(en.map((doc) => doc.route)).toEqual(["/en/start"]);
   });
 
@@ -855,17 +981,19 @@ describe("buildMcpData", () => {
       title: "Installation",
     });
 
-    // Documents are mapped down to the four MCP fields and skip hidden pages.
+    // Documents are mapped down to the five MCP fields and skip hidden pages.
     const doc = data.documents.find(
       (entry) => entry.route === "/guides/install"
     );
     expect(doc).toBeDefined();
     expect(Object.keys(doc ?? {}).toSorted()).toStrictEqual([
       "content",
+      "contentType",
       "description",
       "route",
       "title",
     ]);
+    expect(doc?.contentType).toBe("doc");
     expect(doc?.title).toBe("Installation");
     expect(data.documents.some((entry) => entry.route === "/secret")).toBe(
       false

--- a/packages/blume/test/mcp.test.ts
+++ b/packages/blume/test/mcp.test.ts
@@ -244,6 +244,7 @@ describe("MCP content-type filtering", () => {
         content: "RFC: how Blume endpoints declare request schemas.",
         contentType: "rfc",
         description: "RFC for request validation",
+        facets: { domain: "architecture", status: "enforced" },
         route: "/rfcs/schemas",
         title: "Request schemas",
       },
@@ -253,6 +254,7 @@ describe("MCP content-type filtering", () => {
       {
         contentType: "rfc",
         description: "RFC for request validation",
+        facets: { domain: "architecture", status: "enforced" },
         indexable: true,
         lastModified: null,
         route: "/rfcs/schemas",
@@ -316,6 +318,54 @@ describe("MCP content-type filtering", () => {
 
     const all = JSON.parse(
       await callTyped("list_pages", { contentTypes: ["doc", "rfc"] })
+    ) as unknown[];
+    expect(all.length).toBe(3);
+  });
+
+  it("search_docs filters hits by declared facet values", async () => {
+    const enforced = JSON.parse(
+      await callTyped("search_docs", {
+        filters: { status: "enforced" },
+        query: "blume",
+      })
+    ) as { facets?: Record<string, string>; route: string }[];
+    expect(enforced.map((hit) => hit.route)).toEqual(["/rfcs/schemas"]);
+    // Hits carry their facet values, so an agent sees why a page matched.
+    expect(enforced[0]?.facets).toStrictEqual({
+      domain: "architecture",
+      status: "enforced",
+    });
+
+    const none = JSON.parse(
+      await callTyped("search_docs", {
+        filters: { status: "draft" },
+        query: "blume",
+      })
+    ) as unknown[];
+    expect(none).toEqual([]);
+  });
+
+  it("list_pages filters routes by facets, composing with contentTypes", async () => {
+    const enforced = JSON.parse(
+      await callTyped("list_pages", {
+        contentTypes: ["rfc"],
+        filters: { domain: "architecture", status: "enforced" },
+      })
+    ) as { facets?: Record<string, string>; route: string }[];
+    expect(enforced.map((page) => page.route)).toEqual(["/rfcs/schemas"]);
+    expect(enforced[0]?.facets).toStrictEqual({
+      domain: "architecture",
+      status: "enforced",
+    });
+
+    // Pages without facet values never match a facet filter...
+    const none = JSON.parse(
+      await callTyped("list_pages", { filters: { status: "draft" } })
+    ) as unknown[];
+    expect(none).toEqual([]);
+    // ...and an empty filters object means "no filter".
+    const all = JSON.parse(
+      await callTyped("list_pages", { filters: {} })
     ) as unknown[];
     expect(all.length).toBe(3);
   });
@@ -550,6 +600,56 @@ describe("orama index helpers", () => {
     ]);
     // An empty list means "no filter", matching the MCP tool contract.
     const all = await queryOramaIndex(db, "blume", 5, { contentTypes: [] });
+    expect(all.length).toBe(3);
+  });
+
+  it("filters results to documents matching every facet", async () => {
+    const db = await buildOramaIndex([
+      {
+        content: "Blume RFC on request schemas.",
+        contentType: "rfc",
+        description: "",
+        facets: { domain: "architecture", status: "enforced" },
+        route: "/rfcs/schemas",
+        title: "Request schemas",
+      },
+      {
+        content: "Blume RFC on naming conventions.",
+        contentType: "rfc",
+        description: "",
+        facets: { domain: "architecture", status: "draft" },
+        route: "/rfcs/naming",
+        title: "Naming",
+      },
+      {
+        // No facets: excluded by any facet filter.
+        content: "Blume installation guide.",
+        contentType: "doc",
+        description: "",
+        route: "/install",
+        title: "Install",
+      },
+    ]);
+    // Every entry must match (AND semantics across keys).
+    const enforced = await queryOramaIndex(db, "blume", 5, {
+      facets: { domain: "architecture", status: "enforced" },
+    });
+    expect(enforced.map((doc) => doc.route)).toEqual(["/rfcs/schemas"]);
+    const architecture = await queryOramaIndex(db, "blume", 5, {
+      facets: { domain: "architecture" },
+    });
+    expect(architecture.map((doc) => doc.route).toSorted()).toEqual([
+      "/rfcs/naming",
+      "/rfcs/schemas",
+    ]);
+    // Facet filters compose with the content-type filter.
+    const composed = await queryOramaIndex(db, "blume", 5, {
+      contentTypes: ["rfc"],
+      facets: { status: "draft" },
+    });
+    expect(composed.map((doc) => doc.route)).toEqual(["/rfcs/naming"]);
+    // An empty map means "no filter".
+    const all = await queryOramaIndex(db, "blume", 5, { facets: {} });
     expect(all.length).toBe(3);
   });
 
@@ -936,6 +1036,35 @@ afterAll(async () => {
 });
 
 describe("buildMcpData", () => {
+  it("carries declared facet values onto routes and search documents", async () => {
+    const project = await scanFixture({
+      "blume.config.ts": `const str = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (value) =>
+      typeof value === "string"
+        ? { value }
+        : { issues: [{ message: "must be a string" }] },
+  },
+};
+export default { content: { types: { rfc: { facets: ["status"], frontmatter: { status: str } } } } };`,
+      "docs/guide.md": "---\ntitle: Guide\n---\n# Guide\n\nPlain doc.\n",
+      "docs/rfc.md":
+        "---\ntitle: RFC 1\ntype: rfc\nstatus: enforced\n---\n# RFC 1\n\nBody.\n",
+    });
+
+    const data = await buildMcpData(project);
+
+    const rfcRoute = data.routes.find((route) => route.route === "/rfc");
+    expect(rfcRoute?.facets).toStrictEqual({ status: "enforced" });
+    const rfcDoc = data.documents.find((doc) => doc.route === "/rfc");
+    expect(rfcDoc?.facets).toStrictEqual({ status: "enforced" });
+    // Pages without declared facets omit the field entirely.
+    const guide = data.routes.find((route) => route.route === "/guide");
+    expect(guide && "facets" in guide).toBe(false);
+  });
+
   it("builds a snapshot, honoring config and filtering hidden routes", async () => {
     const project = await scanFixture({
       "blume.config.ts":

--- a/packages/blume/test/scan-project.test.ts
+++ b/packages/blume/test/scan-project.test.ts
@@ -63,6 +63,41 @@ describe("scanProject", () => {
     expect(routesOf(project.manifest.routes)).toStrictEqual(["/", "/draft"]);
   });
 
+  it("threads content.types frontmatter through to page validation", async () => {
+    // A dependency-free Standard Schema, so the temp config needs no imports.
+    const project = await scanProject(
+      await makeProject({
+        "blume.config.ts": `const status = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (value) =>
+      typeof value === "string"
+        ? { value }
+        : { issues: [{ message: "must be a string" }] },
+  },
+};
+export default { content: { types: { rfc: { frontmatter: { status } } } } };`,
+        "docs/guide.md": "---\ntitle: Guide\n---\n# Guide\n",
+        "docs/incomplete.md": "---\ntitle: RFC 2\ntype: rfc\n---\n# RFC 2\n",
+        "docs/rfc.md":
+          "---\ntitle: RFC 1\ntype: rfc\nstatus: enforced\n---\n# RFC 1\n",
+      })
+    );
+
+    const byRoute = new Map(
+      project.graph.pages.map((page) => [page.route, page])
+    );
+    expect(byRoute.get("/rfc")?.custom).toStrictEqual({ status: "enforced" });
+    // The per-type key applies only to `type: rfc` pages, so the plain doc
+    // page carries no custom values and the incomplete RFC is rejected.
+    expect(byRoute.get("/guide")?.custom).toBeUndefined();
+    expect(byRoute.has("/incomplete")).toBe(false);
+    expect(project.diagnostics.map((d) => d.code)).toContain(
+      "BLUME_FRONTMATTER_INVALID"
+    );
+  });
+
   it("aggregates content diagnostics without throwing", async () => {
     const project = await scanProject(await makeProject(CONTENT));
     expect(project.diagnostics.map((d) => d.code)).toContain(

--- a/packages/blume/test/search-providers.test.ts
+++ b/packages/blume/test/search-providers.test.ts
@@ -121,6 +121,7 @@ describe("toSearchRecords", () => {
       {
         breadcrumb: ["Guides"],
         content: "body",
+        contentType: "doc",
         description: "desc",
         locale: "en",
         route: "/a",
@@ -147,6 +148,7 @@ describe("toSearchRecords", () => {
       {
         breadcrumb: [],
         content: "",
+        contentType: "doc",
         description: "",
         locale: "",
         route: "/x",

--- a/packages/blume/test/search.test.ts
+++ b/packages/blume/test/search.test.ts
@@ -6,8 +6,10 @@ import { join } from "pathe";
 
 import type { BlumeProject } from "../src/core/project-graph.ts";
 import { blumeConfigSchema, pageMetaSchema } from "../src/core/schema.ts";
+import type { ResolvedConfig } from "../src/core/schema.ts";
 import type { PageRecord, RouteManifestEntry } from "../src/core/types.ts";
 import { buildSearchDocuments } from "../src/search/documents.ts";
+import { pageFacets } from "../src/search/facets.ts";
 
 let root: string;
 
@@ -51,7 +53,11 @@ const projectWith = (
   pages: PageRecord[],
   routes: RouteManifestEntry[]
 ): BlumeProject =>
-  ({ graph: { pages }, manifest: { routes } }) as unknown as BlumeProject;
+  ({
+    config: blumeConfigSchema.parse({}),
+    graph: { pages },
+    manifest: { routes },
+  }) as unknown as BlumeProject;
 
 const VIS_BODY = [
   "---",
@@ -83,7 +89,88 @@ afterAll(async () => {
   await rm(root, { force: true, recursive: true });
 });
 
+/** A resolved config with the given facet names declared for `type: rfc`. */
+const configWithRfcFacets = (facets: string[]): ResolvedConfig => {
+  const base = blumeConfigSchema.parse({});
+  return {
+    ...base,
+    // Bypasses parse-time facet validation (which needs schema fixtures);
+    // `pageFacets` reads only the resolved declaration.
+    content: {
+      ...base.content,
+      types: { rfc: { facets, frontmatter: {} } },
+    },
+  };
+};
+
+describe("pageFacets", () => {
+  it("resolves declared facets, stringifying numbers and booleans", () => {
+    const facets = pageFacets(
+      {
+        contentType: "rfc",
+        custom: {
+          domain: "architecture",
+          enforced: true,
+          revision: 3,
+          undeclared: "ignored",
+        },
+      },
+      configWithRfcFacets(["domain", "enforced", "revision", "absent"])
+    );
+    expect(facets).toStrictEqual({
+      domain: "architecture",
+      enforced: "true",
+      revision: "3",
+    });
+  });
+
+  it("skips non-scalar values and returns undefined when nothing facets", () => {
+    const config = configWithRfcFacets(["meta"]);
+    expect(
+      pageFacets(
+        { contentType: "rfc", custom: { meta: { nested: 1 } } },
+        config
+      )
+    ).toBeUndefined();
+    // No custom values, an undeclared type, and no facet declaration all
+    // resolve to "no facets" rather than an empty object.
+    expect(pageFacets({ contentType: "rfc" }, config)).toBeUndefined();
+    expect(
+      pageFacets({ contentType: "doc", custom: { meta: "x" } }, config)
+    ).toBeUndefined();
+    expect(
+      pageFacets(
+        { contentType: "rfc", custom: { meta: "x" } },
+        configWithRfcFacets([])
+      )
+    ).toBeUndefined();
+  });
+});
+
 describe("buildSearchDocuments", () => {
+  it("emits declared facet values and omits the field elsewhere", async () => {
+    const project = {
+      config: configWithRfcFacets(["status"]),
+      graph: {
+        pages: [
+          page({
+            contentType: "rfc",
+            custom: { status: "enforced" },
+            id: "a.md",
+          }),
+        ],
+      },
+      manifest: { routes: [route({ contentType: "rfc" })] },
+    } as unknown as BlumeProject;
+    const [doc] = await buildSearchDocuments(project);
+    expect(doc?.facets).toStrictEqual({ status: "enforced" });
+
+    const [plain] = await buildSearchDocuments(
+      projectWith([page({ id: "a.md" })], [route({})])
+    );
+    expect(plain && "facets" in plain).toBe(false);
+  });
+
   it("indexes only indexable routes, in manifest order", async () => {
     const docs = await buildSearchDocuments(
       projectWith(

--- a/packages/blume/test/sources.test.ts
+++ b/packages/blume/test/sources.test.ts
@@ -355,6 +355,16 @@ const ctxWith = (extend: FrontmatterExtend): NormalizeContext => ({
   source: { name: "filesystem", staged: false },
 });
 
+const typedCtx = (
+  typeFrontmatter: NonNullable<NormalizeContext["typeFrontmatter"]>,
+  extend?: FrontmatterExtend
+): NormalizeContext => ({
+  defaultType: "doc",
+  frontmatterExtend: extend,
+  source: { name: "filesystem", staged: false },
+  typeFrontmatter,
+});
+
 describe("normalizeEntry with frontmatter.extend", () => {
   it("rejects unknown keys when no extension is configured", () => {
     const { pages, diagnostics } = normalizeEntry(
@@ -456,6 +466,81 @@ describe("normalizeEntry with frontmatter.extend", () => {
     );
     expect(pages).toHaveLength(0);
     expect(diagnostics[0]?.message).toContain("Async schemas");
+  });
+});
+
+describe("normalizeEntry with content.types frontmatter", () => {
+  it("enforces a per-type key only on pages of that type", () => {
+    const ctx = typedCtx({ rfc: { status: z.string() } });
+
+    const rfc = normalizeEntry(entryWith({ title: "RFC 1", type: "rfc" }), ctx);
+    expect(rfc.pages).toHaveLength(0);
+    expect(rfc.diagnostics[0]?.code).toBe("BLUME_FRONTMATTER_INVALID");
+    expect(rfc.diagnostics[0]?.schemaPath).toBe("status");
+
+    const doc = normalizeEntry(entryWith({ title: "Guide" }), ctx);
+    expect(doc.diagnostics).toStrictEqual([]);
+    expect(doc.pages[0]?.custom).toBeUndefined();
+  });
+
+  it("preserves validated per-type values on the page's custom field", () => {
+    const { pages, diagnostics } = normalizeEntry(
+      entryWith({ status: "enforced", title: "RFC 1", type: "rfc" }),
+      typedCtx({ rfc: { status: z.string() } })
+    );
+    expect(diagnostics).toStrictEqual([]);
+    expect(pages[0]?.contentType).toBe("rfc");
+    expect(pages[0]?.custom).toStrictEqual({ status: "enforced" });
+  });
+
+  it("keeps a key declared for another type unknown", () => {
+    // `status` exists only for `rfc`, so on a doc page it's still a typo-level
+    // unknown key — per-type declarations don't loosen other types.
+    const { pages, diagnostics } = normalizeEntry(
+      entryWith({ status: "enforced", title: "Guide" }),
+      typedCtx({ rfc: { status: z.string() } })
+    );
+    expect(pages).toHaveLength(0);
+    expect(diagnostics[0]?.code).toBe("BLUME_FRONTMATTER_INVALID");
+    expect(diagnostics[0]?.message).toContain("status");
+  });
+
+  it("merges site-wide extend keys with the page type's keys", () => {
+    const { pages, diagnostics } = normalizeEntry(
+      entryWith({
+        owner: "@sam",
+        status: "draft",
+        title: "RFC 1",
+        type: "rfc",
+      }),
+      typedCtx({ rfc: { status: z.string() } }, { owner: z.string() })
+    );
+    expect(diagnostics).toStrictEqual([]);
+    expect(pages[0]?.custom).toStrictEqual({
+      owner: "@sam",
+      status: "draft",
+    });
+  });
+
+  it("applies the default type's declaration to pages that set no type", () => {
+    const { pages, diagnostics } = normalizeEntry(
+      entryWith({ owner: "@sam", title: "Guide" }),
+      typedCtx({ doc: { owner: z.string() } })
+    );
+    expect(diagnostics).toStrictEqual([]);
+    expect(pages[0]?.contentType).toBe("doc");
+    expect(pages[0]?.custom).toStrictEqual({ owner: "@sam" });
+  });
+
+  it("rejects a non-string type through the strict page schema", () => {
+    // Type resolution falls back to `defaultType` for the carve-out, but the
+    // strict parse still owns rejecting the malformed `type` itself.
+    const { pages, diagnostics } = normalizeEntry(
+      entryWith({ title: "Guide", type: 5 }),
+      typedCtx({ rfc: { status: z.string() } })
+    );
+    expect(pages).toHaveLength(0);
+    expect(diagnostics[0]?.code).toBe("BLUME_FRONTMATTER_INVALID");
   });
 });
 


### PR DESCRIPTION
## Summary
- `content.types.<type>.frontmatter`: custom frontmatter keys scoped to one content type, layered on the site-wide `frontmatter.extend` — an RFC's `status` can be required type-wide without loosening other pages. Reuses the extend machinery (Standard Schema contract, strict-parse carve-out); built-in fields can't be redeclared and a key can't be declared both site-wide and per-type.
- `contentTypes` filter on the MCP `search_docs` and `list_pages` tools; search documents carry the resolved page type end to end (`blume-search.json` included) and the shared Orama index gains a `contentType` enum filtered like the locale enum.
- `content.types.<type>.facets`: declared custom keys whose values become filterable metadata. Both MCP tools accept a `filters` object (`{"domain": "architecture", "status": "enforced"}`, AND semantics), results echo their facet values, and `list_pages` doubles as type/facet discovery. Facet names are validated at config load against the declared custom keys; the Orama index flattens facets to `key:value` terms in one `facetTerms` enum-array (`containsAll`), so a static schema serves any project's facet vocabulary.
- Docs for all three surfaces and three minor changesets.

Resolves #167

## Test plan
- [x] `bun test` (2271 tests) and `bun run test:coverage` — per-file 98% gate passes, all touched files at 100%
- [x] `bun run typecheck` including the `config-input.ts` drift guard
- [x] New tests: per-type validation (unit + `scanProject` e2e), config collision/facet guards, Orama `contentTypes`/`facets` filters, MCP tool inputs incl. empty-filter contracts, `buildMcpData` facet snapshot
- [ ] Manual: point an MCP client at a site with `type: rfc` pages and exercise `search_docs`/`list_pages` with `contentTypes` + `filters`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-content-type frontmatter schemas with validation, default-type handling, and custom fields.
  * Added searchable content facets with string, numeric, and boolean values.
  * Added content-type and facet filtering to MCP document searches and page listings.
  * Search and MCP results now include content types and applicable facet values.
* **Documentation**
  * Documented content-type configuration, frontmatter rules, facets, and MCP filters.
* **Bug Fixes**
  * Improved validation for duplicate, unknown, and undeclared frontmatter fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->