### PR TITLE
fix(openapi): keep diacritics in tag slugs

### DIFF
--- a/.changeset/six-sites-hammer.md
+++ b/.changeset/six-sites-hammer.md
@@ -1,5 +1,9 @@
 ---
-"blume": patch
+"blume": minor
 ---
 
-Keep Unicode letters in OpenAPI tag slugs so diacritics are not treated as word separators. Labels humanized from those slugs no longer split words like `Größe` into `Gr E`.
+Keep Unicode letters in OpenAPI tag slugs, and label tag sidebar groups with the spec's own tag names.
+
+Slugs derived from OpenAPI tag names (and reference-source labels) now keep Unicode letters and numbers instead of stripping them to hyphens, with NFC normalization so canonically equivalent spellings share one slug. Sidebar groups for tag sections now take their label directly from the spec's `tags[].name` (overridable with a `meta.ts` title), so authored casing like `OAuth2`, `iOS SDK`, or `Größe` renders verbatim instead of being re-humanized from the slug. Canonical and `og:image` URLs percent-encode route-derived paths, matching the sitemap. The MCP server card's reverse-DNS `name` now transliterates to ASCII (`Café Docs` → `cafe-docs`) to stay within the registry schema.
+
+**Note:** operation-page URLs change for specs whose tag names, operation ids, or source labels contain non-ASCII characters — `Größe` operations move from `/api/gr-e/...` to `/api/größe/...`, and previously letterless slugs leave the `operations` fallback. If such URLs are already deployed, add entries under `redirects` in `blume.config` to forward the old routes.

--- a/.changeset/six-sites-hammer.md
+++ b/.changeset/six-sites-hammer.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Keep Unicode letters in OpenAPI tag slugs so diacritics are not treated as word separators. Labels humanized from those slugs no longer split words like `Größe` into `Gr E`.

--- a/packages/blume/src/ai/mcp/discovery.ts
+++ b/packages/blume/src/ai/mcp/discovery.ts
@@ -1,6 +1,5 @@
 import { withBasePath } from "../../core/base-path.ts";
-import { trimEnd } from "../../core/trim.ts";
-import { slugify } from "../../openapi/references.ts";
+import { trimChar, trimEnd } from "../../core/trim.ts";
 import { MCP_TOOLS } from "./tools.ts";
 
 /** Inputs needed to describe the MCP server in discovery documents. */
@@ -49,10 +48,29 @@ const CARD_TEXT_MAX = 100;
 const truncate = (text: string): string =>
   text.length > CARD_TEXT_MAX ? `${text.slice(0, CARD_TEXT_MAX - 1)}…` : text;
 
+// The server-card schema constrains `name` to `namespace/server` in ASCII
+// (`^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$`), so the display name cannot reuse the
+// route slugifier, which keeps Unicode letters. Decompose (NFKD) and drop
+// combining marks first so an accented name transliterates (`Café` → `cafe`)
+// instead of losing the letter.
+const NON_ASCII_SLUG = /[^a-z0-9]+/gu;
+const COMBINING_MARKS = /\p{M}+/gu;
+
+const asciiSlugify = (text: string): string =>
+  trimChar(
+    text
+      .normalize("NFKD")
+      .replace(COMBINING_MARKS, "")
+      .toLowerCase()
+      .replace(NON_ASCII_SLUG, "-"),
+    "-"
+  );
+
 /**
  * The card's identity in the schema's reverse-DNS `namespace/server` form:
  * the site hostname reversed (`useblume.dev` → `dev.useblume`), or
- * `localhost` when no site is configured, plus the slugged display name.
+ * `localhost` when no site is configured, plus the slugged display name (an
+ * entirely non-ASCII name falls back to `docs`).
  */
 const reverseDnsName = (input: McpDiscoveryInput): string => {
   let namespace = "localhost";
@@ -66,7 +84,7 @@ const reverseDnsName = (input: McpDiscoveryInput): string => {
       // Not a parsable URL; the local namespace is honest enough.
     }
   }
-  return `${namespace}/${slugify(input.name) || "docs"}`;
+  return `${namespace}/${asciiSlugify(input.name) || "docs"}`;
 };
 
 const HTTP_URL = /^https?:\/\//u;

--- a/packages/blume/src/astro/templates.ts
+++ b/packages/blume/src/astro/templates.ts
@@ -1680,8 +1680,11 @@ const frontmatter = entry.data ?? {};
 const seo = frontmatter.seo ?? {};
 const base = data.config.site ? data.config.site.replace(/\\/$/, "") : null;
 
+// Percent-encode the route-derived path (the sitemap convention): a Unicode
+// slug (\`/api/größe\`) is not legal in a raw URI, and crawlers compare
+// canonical against the sitemap's encoded <loc> byte-for-byte.
 const ogPath = data.config.og.enabled
-  ? \`/og/\${route === "/" ? "index" : route.slice(1)}.png\`
+  ? encodeURI(\`/og/\${route === "/" ? "index" : route.slice(1)}.png\`)
   : null;
 const ogRel = seo.image ?? ogPath;
 // Absolute URLs also carry the deployment base (the page is served under it):
@@ -1700,7 +1703,7 @@ const x = { ...data.config.x, ...(seo.x?.creator ? { creator: seo.x.creator } : 
 const basedRoute = withBase(route);
 const canonical =
   seo.canonical ??
-  (base ? \`\${base}\${basedRoute === "/" ? "" : basedRoute}\` : null);
+  (base ? \`\${base}\${basedRoute === "/" ? "" : encodeURI(basedRoute)}\` : null);
 
 // Locale resolution. With i18n on, pick the active locale's nav + dictionary,
 // build hreflang alternates, and derive the language-switcher targets.

--- a/packages/blume/src/components/layout/PageLayout.astro
+++ b/packages/blume/src/components/layout/PageLayout.astro
@@ -152,9 +152,13 @@ const basedRoute = withBase(route);
 // strip it before joining with the root-relative route so canonical/og URLs
 // don't come out double-slashed — the catch-all strips it the same way.
 const siteBase = siteUrl ? siteUrl.replace(/\/$/u, "") : null;
+// The route-derived part is percent-encoded (the sitemap convention) so a
+// Unicode route slug yields a legal URI that byte-matches the sitemap <loc>.
 const resolvedCanonical =
   canonical ??
-  (siteBase ? `${siteBase}${basedRoute === "/" ? "" : basedRoute}` : null);
+  (siteBase
+    ? `${siteBase}${basedRoute === "/" ? "" : encodeURI(basedRoute)}`
+    : null);
 // An explicit `ogImage` wins. A root-relative path (e.g. an image dropped in
 // `public/`) is resolved against the site URL so crawlers get an absolute
 // `og:image`; an already-absolute URL passes through untouched. Otherwise fall
@@ -164,7 +168,7 @@ const absolutizeOgImage = (value: string): string =>
 const resolvedOgImage = ogImage
   ? absolutizeOgImage(ogImage)
   : ogEnabled && siteBase
-    ? `${siteBase}${withBase(`/og/${ogSlug}.png`)}`
+    ? `${siteBase}${encodeURI(withBase(`/og/${ogSlug}.png`))}`
     : null;
 // Only the generated card has a known size and format, so its dimensions are
 // declared for crawlers; a user-supplied `ogImage` could be any image.

--- a/packages/blume/src/core/project-graph.ts
+++ b/packages/blume/src/core/project-graph.ts
@@ -262,6 +262,17 @@ export const scanProject = async (
     discoverFolderMeta(metaSources, { localeDirs }),
   ]);
 
+  // Folder meta contributed by the sources themselves (the OpenAPI source
+  // labels each tag directory with the spec's own tag name). It applies to
+  // every locale, so it merges into the shared map — beneath user-authored
+  // entries, which are spread last and win.
+  const sharedFolderMeta = new Map([
+    ...loaded.flatMap(({ folderMeta: sourceMeta }) =>
+      Object.entries(sourceMeta ?? {})
+    ),
+    ...folderMeta.shared,
+  ]);
+
   const {
     diagnostics: contentDiagnostics,
     droppedPages,
@@ -301,7 +312,7 @@ export const scanProject = async (
     folderMeta: folderMeta.meta,
     i18n: config.i18n,
     navigation: config.navigation,
-    sharedFolderMeta: folderMeta.shared,
+    sharedFolderMeta,
   });
   const manifest = buildManifest({ config, context, graph });
 

--- a/packages/blume/src/core/sources/types.ts
+++ b/packages/blume/src/core/sources/types.ts
@@ -1,4 +1,8 @@
-import type { FrontmatterExtend, ResolvedI18nConfig } from "../schema.ts";
+import type {
+  FolderMeta,
+  FrontmatterExtend,
+  ResolvedI18nConfig,
+} from "../schema.ts";
 import type { Diagnostic } from "../types.ts";
 
 /**
@@ -40,6 +44,14 @@ export interface SourceLoadResult {
   entries: SourceEntry[];
   /** Source-level diagnostics (e.g. an offline cache fallback warning). */
   diagnostics: Diagnostic[];
+  /**
+   * Folder meta the source derives for the sidebar groups its entries create,
+   * keyed by locale-stripped group path (the `meta.ts` key space). The OpenAPI
+   * source labels each tag directory with the spec's own tag name, so the
+   * sidebar shows `OAuth2`/`Größe` instead of a re-humanized slug. Merged
+   * beneath user-authored meta files, which always win.
+   */
+  folderMeta?: Record<string, FolderMeta>;
 }
 
 /**

--- a/packages/blume/src/openapi/model.ts
+++ b/packages/blume/src/openapi/model.ts
@@ -19,7 +19,7 @@ export type ApiDocument = Document;
 // Keep Unicode letters/numbers so diacritics stay in the slug. ASCII-only
 // stripping turned `Größe` into `gr-e`, and the nav humanizer then rendered
 // that as `Gr E`.
-const NON_SLUG = /[^\p{L}\p{N}]+/gu;
+const NON_SLUG = /[^\p{L}\p{M}\p{N}]+/gu;
 const SLUG_EDGES = /^-+|-+$/gu;
 
 /** Lowercase, URL-safe slug: `Add a Pet!` -> `add-a-pet`. */

--- a/packages/blume/src/openapi/model.ts
+++ b/packages/blume/src/openapi/model.ts
@@ -4,6 +4,13 @@ import type {
   PathItemObject,
 } from "@scalar/openapi-types/3.1";
 
+import { slugify } from "./references.ts";
+
+// The slug rules live with the reference resolver so operation routes and
+// reference-source tokens can never drift apart; re-exported for existing
+// importers.
+export { slugify } from "./references.ts";
+
 /**
  * Blume's own OpenAPI model. Specs are parsed and upgraded to 3.1 (see
  * `parse.ts`) with internal `$ref`s left intact — the document stays
@@ -15,16 +22,6 @@ import type {
 
 /** A normalized OpenAPI 3.1 document, internal `$ref`s intact. */
 export type ApiDocument = Document;
-
-// Keep Unicode letters/numbers so diacritics stay in the slug. ASCII-only
-// stripping turned `Größe` into `gr-e`, and the nav humanizer then rendered
-// that as `Gr E`.
-const NON_SLUG = /[^\p{L}\p{M}\p{N}]+/gu;
-const SLUG_EDGES = /^-+|-+$/gu;
-
-/** Lowercase, URL-safe slug: `Add a Pet!` -> `add-a-pet`. */
-export const slugify = (text: string): string =>
-  text.toLowerCase().replace(NON_SLUG, "-").replace(SLUG_EDGES, "");
 
 /** The HTTP methods an OpenAPI path item may declare, in spec order. */
 export const HTTP_METHODS = [

--- a/packages/blume/src/openapi/model.ts
+++ b/packages/blume/src/openapi/model.ts
@@ -16,7 +16,10 @@ import type {
 /** A normalized OpenAPI 3.1 document, internal `$ref`s intact. */
 export type ApiDocument = Document;
 
-const NON_SLUG = /[^a-z0-9]+/gu;
+// Keep Unicode letters/numbers so diacritics stay in the slug. ASCII-only
+// stripping turned `Größe` into `gr-e`, and the nav humanizer then rendered
+// that as `Gr E`.
+const NON_SLUG = /[^\p{L}\p{N}]+/gu;
 const SLUG_EDGES = /^-+|-+$/gu;
 
 /** Lowercase, URL-safe slug: `Add a Pet!` -> `add-a-pet`. */
@@ -103,8 +106,8 @@ const isOperation = (value: unknown): value is OperationObject =>
 
 /**
  * Assign each distinct tag name a unique slug. `slugify` can collapse
- * different names onto one value — any two all-non-ASCII tags (`ペット`,
- * `注文`) both fall through to the `operations` fallback — and a shared slug
+ * different names onto one value — any two punctuation-only tags (`!!!`,
+ * `???`) both fall through to the `operations` fallback — and a shared slug
  * silently merges the tags' routes, sidebar groups, and overview sections.
  * Collisions gain `-2`, `-3`, … in first-seen order.
  */

--- a/packages/blume/src/openapi/references.ts
+++ b/packages/blume/src/openapi/references.ts
@@ -62,10 +62,37 @@ export interface ReferenceSource {
   collisions?: string[];
 }
 
+// Keep Unicode letters/marks/numbers so diacritics stay in the slug (ASCII-only
+// stripping turned `Größe` into `gr-e`, which the nav humanizer rendered as
+// `Gr E`); `\p{M}` keeps combining marks attached to their base letter, which
+// NFC cannot always compose away (Devanagari vowel signs, Turkish `İ`'s
+// lowercased combining dot).
 const NON_SLUG = /[^\p{L}\p{M}\p{N}]+/gu;
+// Format characters (ZWNJ, ZWJ, bidi controls) separate no words — hyphenating
+// them would split Persian/Indic compounds the way ASCII stripping split
+// `Größe` — so they are dropped, not replaced.
+const FORMAT_CHARS = /\p{Cf}/gu;
+// A combining mark at the start of the slug has no base letter to attach to
+// (it would glue onto the preceding `/` in a URL), and a marks-only slug must
+// come out empty so callers' fallbacks (`operations`, `reference`) fire.
+const LEADING_MARKS = /^\p{M}+/u;
 
+/**
+ * Lowercase, hyphen-separated slug: `Add a Pet!` -> `add-a-pet`. Unicode
+ * letters are kept (`Größe` -> `größe`), NFC-normalized so canonically
+ * equivalent spellings (NFD input from macOS tooling) land on one slug.
+ * Non-ASCII slugs rely on the emitter percent-encoding the URL where a raw
+ * URI is required (sitemap, canonical).
+ */
 export const slugify = (text: string): string =>
-  trimChar(text.toLowerCase().replace(NON_SLUG, "-"), "-");
+  trimChar(
+    text
+      .normalize("NFC")
+      .toLowerCase()
+      .replace(FORMAT_CHARS, "")
+      .replace(NON_SLUG, "-"),
+    "-"
+  ).replace(LEADING_MARKS, "");
 
 /** Normalize a configured route to a single leading slash, no trailing slash. */
 export const normalizeRoute = (route: string): string => {

--- a/packages/blume/src/openapi/references.ts
+++ b/packages/blume/src/openapi/references.ts
@@ -62,7 +62,7 @@ export interface ReferenceSource {
   collisions?: string[];
 }
 
-const NON_SLUG = /[^a-z0-9]+/gu;
+const NON_SLUG = /[^\p{L}\p{N}]+/gu;
 
 export const slugify = (text: string): string =>
   trimChar(text.toLowerCase().replace(NON_SLUG, "-"), "-");

--- a/packages/blume/src/openapi/references.ts
+++ b/packages/blume/src/openapi/references.ts
@@ -62,7 +62,7 @@ export interface ReferenceSource {
   collisions?: string[];
 }
 
-const NON_SLUG = /[^\p{L}\p{N}]+/gu;
+const NON_SLUG = /[^\p{L}\p{M}\p{N}]+/gu;
 
 export const slugify = (text: string): string =>
   trimChar(text.toLowerCase().replace(NON_SLUG, "-"), "-");

--- a/packages/blume/src/openapi/source.ts
+++ b/packages/blume/src/openapi/source.ts
@@ -1,5 +1,6 @@
 import { withBasePath } from "../core/base-path.ts";
 import matter from "../core/frontmatter.ts";
+import type { FolderMeta } from "../core/schema.ts";
 import { hashText } from "../core/sources/cache.ts";
 import type {
   ContentSource,
@@ -75,10 +76,33 @@ const specEntries = (
   return entries;
 };
 
+/**
+ * Label each tag's sidebar group with the spec's own tag name. The group label
+ * is otherwise re-humanized from the tag's route slug (split on hyphens,
+ * title-cased), which mangles authored casing and symbols — `OAuth2` →
+ * "Oauth2", `Größe` → "Größe" only by luck of the slug. Keys are the tag
+ * directories under the reference route, the same group paths `meta.ts` files
+ * use, so user-authored meta still overrides these.
+ */
+const tagFolderMeta = (
+  spec: ApiSpecData,
+  tags: { slug: string; name: string }[]
+): Record<string, FolderMeta> => {
+  const base = routeToRef(spec.route);
+  return Object.fromEntries(
+    tags.map((tag) => [
+      base ? `${base}/${tag.slug}` : tag.slug,
+      { title: tag.name },
+    ])
+  );
+};
+
 interface LoadedSpec {
   slug: string;
   spec: ApiSpecData;
   entries: SourceEntry[];
+  /** Sidebar-group labels for the spec's tag directories. */
+  folderMeta: Record<string, FolderMeta>;
   /** Non-fatal notes from the load (e.g. an offline cache fallback). */
   diagnostics: Diagnostic[];
 }
@@ -157,6 +181,7 @@ export const openApiSource = (
             : []),
         ],
         entries: specEntries(spec, operations, reference),
+        folderMeta: tagFolderMeta(spec, tags),
         slug: reference.slug,
         spec,
       };
@@ -192,6 +217,7 @@ export const openApiSource = (
       }))
     );
     const data: OpenApiData = {};
+    const folderMeta: Record<string, FolderMeta> = {};
     for (const result of results) {
       if ("severity" in result) {
         diagnostics.push(result);
@@ -199,10 +225,11 @@ export const openApiSource = (
       }
       data[result.slug] = result.spec;
       entries.push(...result.entries);
+      Object.assign(folderMeta, result.folderMeta);
       diagnostics.push(...result.diagnostics);
     }
     parsed = data;
-    return { diagnostics, entries };
+    return { diagnostics, entries, folderMeta };
   };
 
   return {

--- a/packages/blume/test/mcp.test.ts
+++ b/packages/blume/test/mcp.test.ts
@@ -974,6 +974,20 @@ describe("discovery documents", () => {
     );
   });
 
+  it("keeps the reverse-DNS name inside the schema's ASCII pattern", () => {
+    // The server-card schema constrains `name` to ASCII; the route slugifier
+    // keeps Unicode letters, so the card must not reuse it. Accented names
+    // transliterate rather than losing the letter.
+    expect(buildMcpServerCard({ ...input, name: "Café Docs" }).name).toBe(
+      "com.example.docs/cafe-docs"
+    );
+    // An entirely non-ASCII name falls back to `docs` instead of publishing a
+    // schema-invalid identifier.
+    expect(buildMcpServerCard({ ...input, name: "ドキュメント" }).name).toBe(
+      "com.example.docs/docs"
+    );
+  });
+
   it("caps card text at the schema's 100-character limit", () => {
     const card = buildMcpServerCard({ ...input, name: "N".repeat(120) });
     expect((card.description as string).length).toBe(100);

--- a/packages/blume/test/openapi.test.ts
+++ b/packages/blume/test/openapi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 import { join } from "pathe";
@@ -28,9 +28,10 @@ import {
   buildRequestSample,
   sampleLanguages,
 } from "../src/components/openapi/snippets.ts";
+import { scanProject } from "../src/core/project-graph.ts";
 import { blumeConfigSchema } from "../src/core/schema.ts";
 import { resolveSources } from "../src/core/sources/resolve.ts";
-import type { ProjectContext } from "../src/core/types.ts";
+import type { NavNode, ProjectContext } from "../src/core/types.ts";
 import {
   extractOperations,
   operationKey,
@@ -453,15 +454,55 @@ describe("model.extractOperations", () => {
     );
     const byKey = new Map(operations.map((op) => [op.key, op]));
     expect(byKey.get("listchildren")?.tagSlug).toBe("niños");
-    expect(byKey.get("listnfdchildren")?.tagSlug).toBe(nfdNinos.toLowerCase());
+    // The NFD spelling normalizes onto the same slug as the NFC tag; the two
+    // are still distinct tag *names*, so the collision suffix keeps their
+    // routes apart visibly instead of minting a byte-distinct, pixel-identical
+    // twin slug.
+    expect(byKey.get("listnfdchildren")?.tagSlug).toBe("niños-2");
     expect(byKey.get("listsizes")?.tagSlug).toBe("größe");
     expect(
       tags.map((tag) => ({ name: tag.name, slug: tag.slug }))
     ).toStrictEqual([
       { name: "Niños", slug: "niños" },
-      { name: nfdNinos, slug: nfdNinos.toLowerCase() },
+      { name: nfdNinos, slug: "niños-2" },
       { name: "Größe", slug: "größe" },
     ]);
+  });
+
+  it("drops format characters instead of splitting on them", () => {
+    // ZWNJ (U+200C) is orthographically mandatory inside Persian compounds;
+    // turning it into a hyphen re-creates the word-splitting bug this slug
+    // policy exists to fix (the humanizer splits on hyphens).
+    const { operations, tags } = extractOperations(
+      {
+        openapi: "3.1.0",
+        paths: {
+          "/apps": {
+            get: { operationId: "listApps", tags: ["نرم‌افزار"] },
+          },
+        },
+      } as unknown as ApiDocument,
+      "/api"
+    );
+    expect(operations[0]?.tagSlug).toBe("نرمافزار");
+    expect(tags[0]?.slug).toBe("نرمافزار");
+  });
+
+  it("falls back when a tag is only combining marks", () => {
+    // A bare combining mark is truthy but has no base letter — without the
+    // leading-mark trim it would bypass the `operations` fallback and mint an
+    // invisible route segment that glues onto the preceding `/` in URLs.
+    const { operations, tags } = extractOperations(
+      {
+        openapi: "3.1.0",
+        paths: {
+          "/a": { get: { operationId: "a", tags: ["̃"] } },
+        },
+      } as unknown as ApiDocument,
+      "/api"
+    );
+    expect(operations[0]?.tagSlug).toBe("operations");
+    expect(tags[0]?.slug).toBe("operations");
   });
 
   it("falls back when a tag has no letters or numbers", () => {
@@ -1168,13 +1209,19 @@ describe("source.openApiSource", () => {
     const source = openApiSource([reference], ctx(dir));
     expect(isOpenApiSource(source)).toBe(true);
 
-    const { entries, diagnostics } = await source.load();
+    const { entries, diagnostics, folderMeta } = await source.load();
     expect(diagnostics).toStrictEqual([]);
     // 3 operations + 1 overview index.
     expect(entries).toHaveLength(4);
     const refs = entries.map((entry) => entry.ref);
     expect(refs).toContain("api/pet/addpet.mdx");
     expect(refs.at(-1)).toBe("api/index.mdx");
+    // Each tag directory is labeled with the spec's own tag name, so the
+    // sidebar group renders the authored casing instead of a re-humanized slug.
+    expect(folderMeta).toStrictEqual({
+      "api/operations": { title: "Operations" },
+      "api/pet": { title: "pet" },
+    });
 
     const data = source.openApiData();
     expect(data.api?.title).toBe("Petstore");
@@ -1388,6 +1435,51 @@ describe("source.openApiSource", () => {
     } finally {
       globalThis.fetch = original;
       await rm(cacheDir, { force: true, recursive: true });
+    }
+  });
+
+  it("labels tag sidebar groups with the spec's own tag name", async () => {
+    const root = await mkdtemp(join(tmpdir(), "blume-openapi-nav-"));
+    try {
+      await mkdir(join(root, "docs"), { recursive: true });
+      await writeFile(
+        join(root, "blume.config.ts"),
+        'export default {\n  openapi: { enabled: true, route: "/api", spec: "./openapi.json" },\n};\n'
+      );
+      await writeFile(join(root, "docs/index.md"), "# Home\n");
+      await writeFile(
+        join(root, "openapi.json"),
+        JSON.stringify({
+          info: { title: "API", version: "1" },
+          openapi: "3.1.0",
+          paths: {
+            "/token": {
+              post: {
+                operationId: "createToken",
+                summary: "Create token",
+                tags: ["OAuth2"],
+              },
+            },
+          },
+        })
+      );
+      const project = await scanProject(root);
+      const labels: string[] = [];
+      const walk = (nodes: NavNode[]): void => {
+        for (const node of nodes) {
+          if (node.kind === "group") {
+            labels.push(node.label);
+            walk(node.children);
+          }
+        }
+      };
+      walk(project.graph.navigation.sidebar);
+      // The group label is the tag name the spec authored, not a re-humanized
+      // slug ("Oauth2").
+      expect(labels).toContain("OAuth2");
+      expect(labels).not.toContain("Oauth2");
+    } finally {
+      await rm(root, { force: true, recursive: true });
     }
   });
 });

--- a/packages/blume/test/openapi.test.ts
+++ b/packages/blume/test/openapi.test.ts
@@ -397,7 +397,7 @@ describe("model.extractOperations", () => {
     ]);
   });
 
-  it("keeps distinct all-non-ASCII tags on distinct slugs", () => {
+  it("keeps distinct non-Latin tags on distinct letter-preserving slugs", () => {
     const { operations, tags } = extractOperations(
       {
         openapi: "3.1.0",
@@ -410,21 +410,70 @@ describe("model.extractOperations", () => {
       "/api"
     );
     const byKey = new Map(operations.map((op) => [op.key, op]));
-    // Both slugify to nothing and fall back to "operations"; sharing the slug
-    // would silently merge the two tags' routes and sections. Collisions gain
-    // a suffix in first-seen order.
-    expect(byKey.get("listorders")?.tagSlug).toBe("operations");
-    expect(byKey.get("listpets")?.tagSlug).toBe("operations-2");
-    expect(byKey.get("listorders")?.route).toBe("/api/operations/listorders");
-    expect(byKey.get("listpets")?.route).toBe("/api/operations-2/listpets");
-    // The same tag name still shares one slug across its operations.
-    expect(byKey.get("getpet")?.tagSlug).toBe("operations-2");
-    // The tag list resolves to the slugs its operations were routed under.
+    expect(byKey.get("listorders")?.tagSlug).toBe("注文");
+    expect(byKey.get("listpets")?.tagSlug).toBe("ペット");
+    expect(byKey.get("listorders")?.route).toBe("/api/注文/listorders");
+    expect(byKey.get("listpets")?.route).toBe("/api/ペット/listpets");
+    expect(byKey.get("getpet")?.tagSlug).toBe("ペット");
     expect(
       tags.map((tag) => ({ name: tag.name, slug: tag.slug }))
     ).toStrictEqual([
-      { name: "注文", slug: "operations" },
-      { name: "ペット", slug: "operations-2" },
+      { name: "注文", slug: "注文" },
+      { name: "ペット", slug: "ペット" },
+    ]);
+  });
+
+  it("keeps diacritics in tag slugs so nav labels stay one word", () => {
+    const { operations, tags } = extractOperations(
+      {
+        openapi: "3.1.0",
+        paths: {
+          "/children": {
+            get: {
+              operationId: "listChildren",
+              tags: ["Niños"],
+            },
+          },
+          "/sizes": {
+            get: {
+              operationId: "listSizes",
+              tags: ["Größe"],
+            },
+          },
+        },
+      } as unknown as ApiDocument,
+      "/api"
+    );
+    const byKey = new Map(operations.map((op) => [op.key, op]));
+    expect(byKey.get("listchildren")?.tagSlug).toBe("niños");
+    expect(byKey.get("listsizes")?.tagSlug).toBe("größe");
+    expect(
+      tags.map((tag) => ({ name: tag.name, slug: tag.slug }))
+    ).toStrictEqual([
+      { name: "Niños", slug: "niños" },
+      { name: "Größe", slug: "größe" },
+    ]);
+  });
+
+  it("falls back when a tag has no letters or numbers", () => {
+    const { operations, tags } = extractOperations(
+      {
+        openapi: "3.1.0",
+        paths: {
+          "/a": { get: { operationId: "a", tags: ["!!!"] } },
+          "/b": { get: { operationId: "b", tags: ["???"] } },
+        },
+      } as unknown as ApiDocument,
+      "/api"
+    );
+    const byKey = new Map(operations.map((op) => [op.key, op]));
+    expect(byKey.get("a")?.tagSlug).toBe("operations");
+    expect(byKey.get("b")?.tagSlug).toBe("operations-2");
+    expect(
+      tags.map((tag) => ({ name: tag.name, slug: tag.slug }))
+    ).toStrictEqual([
+      { name: "!!!", slug: "operations" },
+      { name: "???", slug: "operations-2" },
     ]);
   });
 

--- a/packages/blume/test/openapi.test.ts
+++ b/packages/blume/test/openapi.test.ts
@@ -424,6 +424,7 @@ describe("model.extractOperations", () => {
   });
 
   it("keeps diacritics in tag slugs so nav labels stay one word", () => {
+    const nfdNinos = "Nin\u0303os";
     const { operations, tags } = extractOperations(
       {
         openapi: "3.1.0",
@@ -432,6 +433,12 @@ describe("model.extractOperations", () => {
             get: {
               operationId: "listChildren",
               tags: ["Niños"],
+            },
+          },
+          "/nfd-children": {
+            get: {
+              operationId: "listNfdChildren",
+              tags: [nfdNinos],
             },
           },
           "/sizes": {
@@ -446,11 +453,13 @@ describe("model.extractOperations", () => {
     );
     const byKey = new Map(operations.map((op) => [op.key, op]));
     expect(byKey.get("listchildren")?.tagSlug).toBe("niños");
+    expect(byKey.get("listnfdchildren")?.tagSlug).toBe(nfdNinos.toLowerCase());
     expect(byKey.get("listsizes")?.tagSlug).toBe("größe");
     expect(
       tags.map((tag) => ({ name: tag.name, slug: tag.slug }))
     ).toStrictEqual([
       { name: "Niños", slug: "niños" },
+      { name: nfdNinos, slug: nfdNinos.toLowerCase() },
       { name: "Größe", slug: "größe" },
     ]);
   });


### PR DESCRIPTION
## Summary
- OpenAPI tag slugify used `/[^a-z0-9]+/`, so letters like `ö`/`ñ` became hyphens
- Nav labels are humanized from that slug → `Größe` rendered as `Gr E`
- Slugify now keeps Unicode letters/numbers (`\p{L}` / `\p{N}`)

## Test plan
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bun run test:coverage`
- [x] Docs build + `apps/docs` dev smoke
- [x] Unit: `Größe` / `Niños` keep diacritics; punctuation-only tags still fall back to `operations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI tag slugs now preserve Unicode letters and numbers, including accented and non-Latin characters.
  * Humanized labels no longer separate diacritics from their associated words.
  * Punctuation-only tags now use a consistent fallback slug, including collision handling.
  * Sidebar labels now preserve authored OpenAPI tag names and casing.
  * Canonical and social image URLs now correctly encode Unicode routes.
  * MCP server names now generate ASCII-compatible identifiers, with a safe fallback for unsupported names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->