### PR TITLE
Segment search text for every non-Latin script

### DIFF
--- a/.changeset/segment-non-latin-scripts.md
+++ b/.changeset/segment-non-latin-scripts.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Segment search text for every non-Latin script, not just Japanese, Chinese, Korean, and Thai. Orama's default tokenizer splits on a Latin-only delimiter class, so Cyrillic, Greek, Hebrew, and Devanagari content collapsed to zero tokens and every query on it silently returned no hits. The script now comes from `Intl.Locale.maximize()`, so `sr-Latn` keeps Orama's tokenizer while `az-Cyrl` is segmented.
+Segment search text for every non-Latin default locale, not just Japanese, Chinese, Korean, and Thai. Orama's default tokenizer keeps only basic Latin letters and digits, so when `i18n.defaultLocale` was a Cyrillic, Greek, Hebrew, or Devanagari language the index collapsed to zero tokens and every query silently returned no hits. The script now comes from `Intl.Locale.maximize()` — `sr-Latn` keeps Orama's tokenizer while `az-Cyrl` is segmented — with legacy tags (`ja_JP.UTF-8`, `zh-cmn-Hans`) resolved by their language subtag, and Latin terms on a segmented index fold diacritics so café still matches cafe. The tokenizer follows the default locale for the whole index, so non-Latin translations on a Latin-default site are unchanged.

--- a/.changeset/segment-non-latin-scripts.md
+++ b/.changeset/segment-non-latin-scripts.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Segment search text for every non-Latin script, not just Japanese, Chinese, Korean, and Thai. Orama's default tokenizer splits on a Latin-only delimiter class, so Cyrillic, Greek, Hebrew, and Devanagari content collapsed to zero tokens and every query on it silently returned no hits. The script now comes from `Intl.Locale.maximize()`, so `sr-Latn` keeps Orama's tokenizer while `az-Cyrl` is segmented.

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -69,7 +69,7 @@ search: {
 
 #### Non-Latin scripts
 
-Orama's standard tokenizer splits on a Latin-only delimiter class, so text in any other script — Japanese, Chinese, Korean and Thai, but equally Russian, Greek, Hebrew and Hindi — would otherwise produce no matches at all. Blume handles this for you: when [`i18n.defaultLocale`](/docs/content/i18n) resolves to a non-Latin script, the index switches to a word-segmenting tokenizer (built on the browser- and Node-native `Intl.Segmenter`). Declaring your site's language is all it takes:
+Orama's standard tokenizer keeps only basic Latin letters, digits and a handful of accented vowels, so text in any other script — Japanese, Chinese, Korean and Thai, but equally Russian, Greek, Hebrew and Hindi — would otherwise produce no matches at all. Blume handles this for you: when [`i18n.defaultLocale`](/docs/content/i18n) resolves to a non-Latin script, the index switches to a word-segmenting tokenizer (built on the browser- and Node-native `Intl.Segmenter`). Declaring your site's language is all it takes:
 
 ```ts blume.config.ts lineNumbers
 i18n: {
@@ -78,7 +78,7 @@ i18n: {
 }
 ```
 
-The same tokenizer serves the search dialog, the MCP server's `search_docs` tool, and Ask AI grounding. On a mixed-language site the whole index shares the default locale's tokenizer — that's safe, because Latin words survive segmentation intact, so pages in English stay searchable alongside the default language. The script is what decides, not the language name: a `sr-Latn` site keeps Orama's tokenizer, while `az-Cyrl` is segmented.
+The same tokenizer serves the search dialog, the MCP server's `search_docs` tool, and Ask AI grounding. The script is what decides, not the language name — `az-Cyrl` is segmented while `sr-Latn` is not — and it is the default locale that decides for the whole index: on a mixed-language site every page shares the default locale's tokenizer. With a non-Latin default that's safe, because Latin words survive segmentation intact, so pages in English stay searchable alongside the default language. The reverse doesn't hold: non-Latin translations on a Latin-default site aren't searchable. Latin-script languages that lean heavily on diacritics (Vietnamese, or Serbian in Latin script) also fare worse on the standard tokenizer, which folds only a few accented vowels and splits words on the rest.
 
 Japanese and Chinese go one step further. Segmenting alone indexes a compound term as its parts — 資金決済法 as 資金, 決済 and 法 — which lets a page mentioning each part somewhere outrank the page the term is actually about. Han, Hiragana and Katakana are therefore indexed as overlapping character pairs, and queries on those indexes prefer pages carrying a term's pairs together, loosening to any-pair matching when no page carries them all, so typing a whole sentence still returns its closest pages. Korean and Thai keep their segmented words.
 

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -67,9 +67,9 @@ search: {
 }
 ```
 
-#### Languages written without spaces
+#### Non-Latin scripts
 
-Orama's standard tokenizer splits on word boundaries that only exist in space-separated scripts, so Japanese, Chinese, Korean, and Thai text would otherwise produce no matches at all. Blume handles this for you: when [`i18n.defaultLocale`](/docs/content/i18n) is one of those languages, the index switches to a word-segmenting tokenizer (built on the browser- and Node-native `Intl.Segmenter`). Declaring your site's language is all it takes:
+Orama's standard tokenizer splits on a Latin-only delimiter class, so text in any other script — Japanese, Chinese, Korean and Thai, but equally Russian, Greek, Hebrew and Hindi — would otherwise produce no matches at all. Blume handles this for you: when [`i18n.defaultLocale`](/docs/content/i18n) resolves to a non-Latin script, the index switches to a word-segmenting tokenizer (built on the browser- and Node-native `Intl.Segmenter`). Declaring your site's language is all it takes:
 
 ```ts blume.config.ts lineNumbers
 i18n: {
@@ -78,7 +78,7 @@ i18n: {
 }
 ```
 
-The same tokenizer serves the search dialog, the MCP server's `search_docs` tool, and Ask AI grounding. On a mixed-language site the whole index shares the default locale's tokenizer — that's safe, because Latin words survive segmentation intact, so pages in English (or any spaced language) stay searchable alongside the default language.
+The same tokenizer serves the search dialog, the MCP server's `search_docs` tool, and Ask AI grounding. On a mixed-language site the whole index shares the default locale's tokenizer — that's safe, because Latin words survive segmentation intact, so pages in English stay searchable alongside the default language. The script is what decides, not the language name: a `sr-Latn` site keeps Orama's tokenizer, while `az-Cyrl` is segmented.
 
 Japanese and Chinese go one step further. Segmenting alone indexes a compound term as its parts — 資金決済法 as 資金, 決済 and 法 — which lets a page mentioning each part somewhere outrank the page the term is actually about. Han, Hiragana and Katakana are therefore indexed as overlapping character pairs, and queries on those indexes prefer pages carrying a term's pairs together, loosening to any-pair matching when no page carries them all, so typing a whole sentence still returns its closest pages. Korean and Thai keep their segmented words.
 
@@ -86,7 +86,7 @@ Japanese and Chinese go one step further. Segmenting alone indexes a compound te
 
 A second keyless, client-side option. It reuses the same `/blume-search.json` index Orama ships and builds a [FlexSearch](https://github.com/nextapps-de/flexsearch) document index in the browser. Works in `blume dev` and `blume build`.
 
-FlexSearch has no equivalent segmentation hook, so for sites in Japanese, Chinese, Korean, or Thai prefer Orama (the default) or [Pagefind](#pagefind), whose `pagefind_extended` binary segments those languages natively.
+FlexSearch has no equivalent segmentation hook, so for sites in a non-Latin script prefer Orama (the default) or [Pagefind](#pagefind), whose `pagefind_extended` binary segments those languages natively.
 
 ```ts blume.config.ts lineNumbers
 search: {

--- a/apps/docs/content/docs/configuration/search.mdx
+++ b/apps/docs/content/docs/configuration/search.mdx
@@ -86,7 +86,7 @@ Japanese and Chinese go one step further. Segmenting alone indexes a compound te
 
 A second keyless, client-side option. It reuses the same `/blume-search.json` index Orama ships and builds a [FlexSearch](https://github.com/nextapps-de/flexsearch) document index in the browser. Works in `blume dev` and `blume build`.
 
-FlexSearch has no equivalent segmentation hook, so for sites in a non-Latin script prefer Orama (the default) or [Pagefind](#pagefind), whose `pagefind_extended` binary segments those languages natively.
+FlexSearch has no equivalent segmentation hook, so for sites in a non-Latin script prefer Orama (the default) or [Pagefind](#pagefind), whose `pagefind_extended` binary indexes a broad set of languages and segments Chinese, Japanese and Korean natively.
 
 ```ts blume.config.ts lineNumbers
 search: {

--- a/packages/blume/src/ai/ask-context.ts
+++ b/packages/blume/src/ai/ask-context.ts
@@ -22,8 +22,8 @@ export interface AskPage {
 export interface AskData {
   /**
    * The site's `i18n.defaultLocale`, when i18n is configured. Selects a
-   * word-segmenting Orama tokenizer for languages written without spaces, so
-   * retrieval can match CJK/Thai content.
+   * word-segmenting Orama tokenizer for every non-Latin script, so retrieval
+   * can match CJK, Cyrillic, Greek, Hebrew, or Devanagari content.
    */
   defaultLocale?: string;
   documents: OramaDoc[];

--- a/packages/blume/src/ai/mcp/data.ts
+++ b/packages/blume/src/ai/mcp/data.ts
@@ -37,8 +37,9 @@ export interface McpData {
   base: string;
   /**
    * The site's `i18n.defaultLocale`, when i18n is configured. Selects a
-   * word-segmenting Orama tokenizer for languages written without spaces, so
-   * `search_docs` can match CJK/Thai content.
+   * word-segmenting Orama tokenizer for every non-Latin script, so
+   * `search_docs` can match CJK, Cyrillic, Greek, Hebrew, or Devanagari
+   * content.
    */
   defaultLocale?: string;
   /**

--- a/packages/blume/src/ai/mcp/server.ts
+++ b/packages/blume/src/ai/mcp/server.ts
@@ -311,8 +311,9 @@ export type OramaIndexProvider = () => Promise<
 
 /**
  * Memoize the search index so every server built from a snapshot shares it.
- * `locale` is the snapshot's `defaultLocale`, forwarded so unspaced scripts
- * (Japanese, Chinese, Korean, Thai) get a word-segmenting tokenizer.
+ * `locale` is the snapshot's `defaultLocale`, forwarded so non-Latin scripts
+ * (Japanese and Chinese, but equally Cyrillic, Greek, Hebrew, Devanagari…)
+ * get a word-segmenting tokenizer.
  */
 export const createIndexProvider = (
   documents: OramaDoc[],

--- a/packages/blume/src/astro/templates.ts
+++ b/packages/blume/src/astro/templates.ts
@@ -1104,7 +1104,7 @@ const SEARCH_BASE_IMPORT =
 /**
  * A client that loads a static `blume-search.json` index (Orama, FlexSearch).
  * `locale` (Orama only) is the site's `i18n.defaultLocale`, which selects a
- * word-segmenting tokenizer for languages written without spaces.
+ * word-segmenting tokenizer for every non-Latin script.
  */
 const staticSearchClient = (module: string, locale?: string): string =>
   `${SEARCH_CLIENT_HEADER}${searchClientImport(module)}${SEARCH_BASE_IMPORT}

--- a/packages/blume/src/components/layout/search/orama.ts
+++ b/packages/blume/src/components/layout/search/orama.ts
@@ -11,8 +11,9 @@ import type { IndexedDocument, SearchFn } from "./types.ts";
  * available in both dev and the production build. A generous match pool is
  * pulled so the section pills can count across the whole result set before the
  * active filter and display limit are applied. `locale` is the site's
- * `i18n.defaultLocale`, baked into the generated client so unspaced scripts
- * (Japanese, Chinese, Korean, Thai) get a word-segmenting tokenizer.
+ * `i18n.defaultLocale`, baked into the generated client so non-Latin scripts
+ * (Japanese and Chinese, but equally Cyrillic, Greek, Hebrew, Devanagari…)
+ * get a word-segmenting tokenizer.
  */
 export const createSearch = async (opts: {
   indexUrl: string;

--- a/packages/blume/src/search/orama-index.ts
+++ b/packages/blume/src/search/orama-index.ts
@@ -56,39 +56,59 @@ const toFacetTerms = (facets: Record<string, string>): string[] =>
 const BOOST = { description: 2, title: 3 };
 
 /**
- * The script Orama's default tokenizer is built for. Its delimiter class is
- * `/[^A-Za-zàèéìòóù0-9_'-]+/`, so every character outside Latin counts as a
- * separator: text in any other script collapses to zero tokens and every
- * query silently returns no hits. Unspaced scripts are the best-known
- * casualty, but the failure is not about spacing — Russian, Greek, Hebrew and
- * Hindi lose their tokens the same way Japanese does.
+ * The script whose text Orama's default tokenizer keeps mostly intact. Its
+ * delimiter class is `/[^A-Za-zàèéìòóù0-9_'-]+/`, so every character outside
+ * that set counts as a separator: text in any other script collapses to zero
+ * tokens and every query silently returns no hits. Unspaced scripts are the
+ * best-known casualty, but the failure is not about spacing — Russian, Greek,
+ * Hebrew and Hindi lose their tokens the same way Japanese does.
  */
 const LATIN_SCRIPT = "Latn";
 
 /**
- * Whether a locale's script needs {@link segmentingTokenizer} in place of
- * Orama's default. The script comes from `Intl.Locale.maximize()`, which fills
- * in the script a bare language tag implies (`ru` → `Cyrl`) and honors an
- * explicit one, so `sr-Latn` keeps the default tokenizer while `az-Cyrl` is
- * segmented. A tag ICU cannot parse throws, and one it knows no script for
- * reports `undefined`; both keep the default tokenizer, which is what those
- * locales already got.
+ * Parse a locale tag, tolerating the legacy forms that reach here from
+ * hand-written config: underscores (`ru_RU`), POSIX suffixes (`ja_JP.UTF-8`,
+ * `zh_TW@Big5`), and extlang tags ICU rejects (`zh-cmn-Hans`). `Intl.Locale`
+ * throws on all of these, so a failed parse retries with the primary language
+ * subtag alone — enough to resolve the script, which is all that gates the
+ * tokenizer. Returns `undefined` when even that subtag is unparseable.
  */
-const needsSegmenting = (locale: string): boolean => {
+const parseLocale = (tag: string): Intl.Locale | undefined => {
+  const hyphenated = tag.replaceAll("_", "-");
   try {
-    const { script } = new Intl.Locale(locale).maximize();
-    return script !== undefined && script !== LATIN_SCRIPT;
+    return new Intl.Locale(hyphenated);
   } catch {
-    return false;
+    // Retry below with the primary subtag.
+  }
+  const [primary = ""] = hyphenated.split("-");
+  try {
+    return new Intl.Locale(primary);
+  } catch {
+    return undefined;
   }
 };
 
 /**
- * Languages indexed as character bigrams rather than whole segments, and
- * queried to match accordingly. Japanese and Chinese write compounds in
- * {@link BIGRAM_SCRIPTS} without delimiters; Korean separates words with
- * spaces and Thai has no comparable bigram convention, so both keep the plain
- * segmented tokens even where a page mixes in Han or kana.
+ * The maximized locale — script and language filled in from CLDR likely-subtags
+ * and alias data, so `ru` resolves to `Cyrl`, `cmn` to the canonical `zh`, and
+ * an explicit script subtag is honored: `sr-Latn` reports `Latn` while
+ * `az-Cyrl` reports `Cyrl`. `undefined` for tags {@link parseLocale} cannot
+ * salvage; a well-formed tag ICU knows nothing about keeps an `undefined`
+ * script instead.
+ */
+const resolveLocale = (tag: string): Intl.Locale | undefined =>
+  parseLocale(tag)?.maximize();
+
+/**
+ * Indexes whose language maximizes to one of these scripts are built as
+ * character bigrams rather than whole segments, and queried to match
+ * accordingly. Japanese and Chinese write compounds in {@link BIGRAM_SCRIPTS}
+ * without delimiters, and the writing system — not the language subtag — is
+ * what carries that convention: `yue` (Cantonese) maximizes to `Hant` and
+ * needs bigrams the same way `zh` does. Korean maximizes to `Kore` and Thai
+ * to `Thai`; Korean separates words with spaces and Thai has no comparable
+ * bigram convention, so both keep the plain segmented tokens even where a
+ * page mixes in Han or kana.
  *
  * Dictionary segmentation alone drops the adjacency that makes a compound term
  * distinctive: 資金決済法 becomes 資金 / 決済 / 法, and because Orama scores a
@@ -97,7 +117,19 @@ const needsSegmenting = (locale: string): boolean => {
  * terms, and dropping the whole-segment tokens keeps a fragment as common as
  * 法 from matching on its own.
  */
-const BIGRAM_LANGUAGES = new Set(["ja", "zh"]);
+const BIGRAM_INDEX_SCRIPTS = new Set(["Hans", "Hant", "Jpan"]);
+
+/**
+ * Whether the index keyed to this tokenizer language is built from bigrams.
+ * {@link segmentingTokenizer} stores the canonical maximized language, so the
+ * builder and the strict pass in {@link queryOramaIndex} share this predicate
+ * — an index is never built from bigrams that the query side then matches
+ * loosely, or vice versa.
+ */
+const isBigramLanguage = (language: string): boolean => {
+  const script = resolveLocale(language)?.script;
+  return script !== undefined && BIGRAM_INDEX_SCRIPTS.has(script);
+};
 
 /**
  * Segments written entirely in these scripts are the ones re-cut into bigrams,
@@ -128,6 +160,23 @@ const TERM =
   /[\p{L}\p{M}\p{N}]+(?:(?:['’](?=\p{L})|(?<=\p{N})[.,](?=\p{N}))[\p{L}\p{M}\p{N}]+)*/gu;
 
 /**
+ * A term written entirely in Latin script (plus digits and the separators
+ * {@link TERM} keeps within a word). Orama's default tokenizer folds the
+ * accented vowels it recognizes (café → cafe), so a segmented index folds
+ * Latin terms too — otherwise switching a Cyrillic- or Greek-default site to
+ * the segmenting tokenizer would silently drop the unaccented-query matches
+ * the default tokenizer provided. Only all-Latin terms fold: marks are
+ * spelling elsewhere (Thai vowels and tones; the breve that separates
+ * Cyrillic й from и), so a term carrying any other script keeps its marks.
+ */
+const LATIN_TERM = /^[\p{Script=Latin}\p{N}'’.,]+$/u;
+
+const MARKS = /\p{M}+/gu;
+
+const foldDiacritics = (term: string): string =>
+  LATIN_TERM.test(term) ? term.normalize("NFD").replace(MARKS, "") : term;
+
+/**
  * Emit every overlapping 2-character window of `run`, or the lone character.
  * Windows are cut by code point: an ideograph outside the basic plane is a
  * surrogate pair, and slicing by code unit would split it into halves that
@@ -155,24 +204,6 @@ const addBigrams = (run: string, tokens: Set<string>): void => {
 };
 
 /**
- * A word-segmenting tokenizer for languages the default splitter can't handle,
- * built on `Intl.Segmenter` (the same engine `@orama/tokenizers` wraps).
- * Input is NFC-normalized and lowercased before segmenting — unlike the
- * upstream tokenizers — so decomposed text (macOS filenames, some CMS
- * pipelines) indexes the same terms a composed query produces, and Latin
- * terms ("GDPR", English pages on a mixed-locale site) still match
- * case-insensitively. Returns `undefined` for languages the default tokenizer
- * already serves, and on runtimes without `Intl.Segmenter`, where the caller
- * falls back to Orama's default.
- *
- * On a {@link BIGRAM_LANGUAGES} index, runs of adjacent
- * {@link BIGRAM_SCRIPTS} segments are joined and re-cut into character
- * bigrams; everything else (Latin, digits, and every segment on a Korean or
- * Thai index) is emitted one {@link TERM} at a time. Separators end a run
- * either way — whether they stand between segments, as 「クーリング・オフ」
- * does, or inside one.
- */
-/**
  * `Intl.Segmenter` is missing on some runtimes even though the lib type
  * declares it, so the constructor's presence is probed before use.
  */
@@ -180,21 +211,39 @@ const hasSegmenter = (
   segmenter: typeof Intl.Segmenter | undefined
 ): segmenter is typeof Intl.Segmenter => typeof segmenter === "function";
 
+/**
+ * A word-segmenting tokenizer for languages the default splitter can't handle,
+ * built on `Intl.Segmenter` (the same engine `@orama/tokenizers` wraps).
+ * Input is NFC-normalized and lowercased before segmenting — unlike the
+ * upstream tokenizers — so decomposed text (macOS filenames, some CMS
+ * pipelines) indexes the same terms a composed query produces, and Latin
+ * terms ("GDPR", English pages on a mixed-locale site) still match
+ * case-insensitively, with their diacritics folded by
+ * {@link foldDiacritics}. Returns `undefined` for scripts the default
+ * tokenizer already serves ({@link resolveLocale} decides, so `sr-Latn` keeps
+ * the default while `az-Cyrl` is segmented), and on runtimes without
+ * `Intl.Segmenter`, where the caller falls back to Orama's default.
+ *
+ * On a {@link BIGRAM_INDEX_SCRIPTS} index, runs of adjacent
+ * {@link BIGRAM_SCRIPTS} segments are joined and re-cut into character
+ * bigrams; everything else (Latin, digits, and every segment on a Korean or
+ * Thai index) is emitted one {@link TERM} at a time. Separators end a run
+ * either way — whether they stand between segments, as 「クーリング・オフ」
+ * does, or inside one.
+ */
 const segmentingTokenizer = (locale?: string): Tokenizer | undefined => {
-  // Underscored tags (`ru_RU`) reach this from hand-written config; ICU only
-  // parses the hyphenated form.
-  const tag = locale?.replaceAll("_", "-") ?? "";
-  const language = tag.toLowerCase().split("-")[0] ?? "";
-  if (!needsSegmenting(tag)) {
+  const resolved = resolveLocale(locale ?? "");
+  if (!resolved?.script || resolved.script === LATIN_SCRIPT) {
     return;
   }
   if (!hasSegmenter(Intl.Segmenter)) {
     return;
   }
+  // The canonical maximized language (`cmn` → `zh`), so the bigram predicate
+  // here and the strict query pass read the same name.
+  const { language } = resolved;
   const segmenter = new Intl.Segmenter(language, { granularity: "word" });
-  // Keyed off the same set the strict query pass reads, so an index is never
-  // built from bigrams that the query side then matches loosely.
-  const bigram = BIGRAM_LANGUAGES.has(language);
+  const bigram = isBigramLanguage(language);
   return {
     language,
     normalizationCache: new Map(),
@@ -213,7 +262,7 @@ const segmentingTokenizer = (locale?: string): Tokenizer | undefined => {
           return;
         }
         flush();
-        tokens.add(term);
+        tokens.add(foldDiacritics(term));
       };
       for (const segment of segmenter.segment(
         raw.normalize("NFC").toLowerCase()
@@ -250,8 +299,10 @@ const segmentingTokenizer = (locale?: string): Tokenizer | undefined => {
  * `i18n.defaultLocale` — swaps in a word-segmenting tokenizer for every
  * non-Latin script, all of which Orama's default tokenizer reduces to zero
  * tokens; the tokenizer belongs to the database, so on a mixed-locale site it
- * applies to every document, which is safe because Latin words survive
- * segmentation intact.
+ * applies to every document. That is safe in one direction only: Latin words
+ * survive segmentation intact, so English pages on a segmented index stay
+ * searchable, but non-Latin translations on a Latin-default index still
+ * collapse to zero tokens.
  */
 export const buildOramaIndex = async (
   documents: OramaDoc[],
@@ -344,7 +395,7 @@ export const queryOramaIndex = async (
   };
   const params =
     Object.keys(where).length > 0 ? { ...unfiltered, where } : unfiltered;
-  const bigrammed = BIGRAM_LANGUAGES.has(db.tokenizer?.language ?? "");
+  const bigrammed = isBigramLanguage(db.tokenizer?.language ?? "");
   // The result-document generic is OramaDoc because `buildOramaIndex` is the
   // only writer to this database and inserts OramaDoc records (plus the
   // derived `facetTerms`).

--- a/packages/blume/src/search/orama-index.ts
+++ b/packages/blume/src/search/orama-index.ts
@@ -56,12 +56,32 @@ const toFacetTerms = (facets: Record<string, string>): string[] =>
 const BOOST = { description: 2, title: 3 };
 
 /**
- * Scripts written without spaces between words. Orama's default tokenizer
- * splits on a Latin-centric delimiter class, so text in these languages
- * collapses to zero tokens and every query silently returns no hits. Keyed by
- * the primary language subtag of `i18n.defaultLocale`.
+ * The script Orama's default tokenizer is built for. Its delimiter class is
+ * `/[^A-Za-zàèéìòóù0-9_'-]+/`, so every character outside Latin counts as a
+ * separator: text in any other script collapses to zero tokens and every
+ * query silently returns no hits. Unspaced scripts are the best-known
+ * casualty, but the failure is not about spacing — Russian, Greek, Hebrew and
+ * Hindi lose their tokens the same way Japanese does.
  */
-const SEGMENTED_LANGUAGES = new Set(["ja", "ko", "th", "zh"]);
+const LATIN_SCRIPT = "Latn";
+
+/**
+ * Whether a locale's script needs {@link segmentingTokenizer} in place of
+ * Orama's default. The script comes from `Intl.Locale.maximize()`, which fills
+ * in the script a bare language tag implies (`ru` → `Cyrl`) and honors an
+ * explicit one, so `sr-Latn` keeps the default tokenizer while `az-Cyrl` is
+ * segmented. A tag ICU cannot parse throws, and one it knows no script for
+ * reports `undefined`; both keep the default tokenizer, which is what those
+ * locales already got.
+ */
+const needsSegmenting = (locale: string): boolean => {
+  try {
+    const { script } = new Intl.Locale(locale).maximize();
+    return script !== undefined && script !== LATIN_SCRIPT;
+  } catch {
+    return false;
+  }
+};
 
 /**
  * Languages indexed as character bigrams rather than whole segments, and
@@ -161,8 +181,11 @@ const hasSegmenter = (
 ): segmenter is typeof Intl.Segmenter => typeof segmenter === "function";
 
 const segmentingTokenizer = (locale?: string): Tokenizer | undefined => {
-  const language = locale?.toLowerCase().split(/[-_]/u)[0] ?? "";
-  if (!SEGMENTED_LANGUAGES.has(language)) {
+  // Underscored tags (`ru_RU`) reach this from hand-written config; ICU only
+  // parses the hyphenated form.
+  const tag = locale?.replaceAll("_", "-") ?? "";
+  const language = tag.toLowerCase().split("-")[0] ?? "";
+  if (!needsSegmenting(tag)) {
     return;
   }
   if (!hasSegmenter(Intl.Segmenter)) {
@@ -224,12 +247,11 @@ const segmentingTokenizer = (locale?: string): Tokenizer | undefined => {
  * Build an in-memory Orama full-text index from search documents. Shared by the
  * Orama client loader (browser), the MCP server, and Ask AI grounding (Node),
  * so ranking is identical wherever docs are queried. `locale` — the site's
- * `i18n.defaultLocale` — swaps in a word-segmenting tokenizer for languages
- * written without spaces (Japanese, Chinese, Korean, Thai); the tokenizer
- * belongs to the database, so on a mixed-locale site it applies to every
- * document, which is safe because words in other scripts — Latin, and
- * mark-bearing scripts like Hebrew or Devanagari — survive segmentation
- * intact.
+ * `i18n.defaultLocale` — swaps in a word-segmenting tokenizer for every
+ * non-Latin script, all of which Orama's default tokenizer reduces to zero
+ * tokens; the tokenizer belongs to the database, so on a mixed-locale site it
+ * applies to every document, which is safe because Latin words survive
+ * segmentation intact.
  */
 export const buildOramaIndex = async (
   documents: OramaDoc[],

--- a/packages/blume/test/mcp.test.ts
+++ b/packages/blume/test/mcp.test.ts
@@ -721,6 +721,100 @@ describe("orama index helpers", () => {
     expect(en.map((doc) => doc.route)).toEqual(["/en/start"]);
   });
 
+  it("segments spaced non-Latin scripts too", async () => {
+    // Spacing is not what breaks tokenization — Orama's Latin-only delimiter
+    // class is, so these lose every token exactly as Japanese does.
+    const cases = [
+      {
+        content: "Контракт авторизации агента",
+        locale: "ru",
+        term: "авторизации",
+      },
+      {
+        content: "Σύμβαση εξουσιοδότησης πράκτορα",
+        locale: "el",
+        term: "εξουσιοδότησης",
+      },
+      { content: "חוזה הרשאה לסוכן", locale: "he", term: "הרשאה" },
+      { content: "एजेंट प्राधिकरण अनुबंध", locale: "hi", term: "प्राधिकरण" },
+    ];
+    const found = await Promise.all(
+      cases.map(async ({ content, locale, term }) => {
+        const doc = {
+          content,
+          description: "",
+          locale,
+          route: "/x",
+          title: "X",
+        };
+        const unsegmented = await buildOramaIndex([doc]);
+        const segmented = await buildOramaIndex([doc], locale);
+        const before = await queryOramaIndex(unsegmented, term, 5);
+        const after = await queryOramaIndex(segmented, term, 5);
+        return [before.length, after.length];
+      })
+    );
+    expect(found).toEqual([
+      [0, 1],
+      [0, 1],
+      [0, 1],
+      [0, 1],
+    ]);
+  });
+
+  it("keeps Orama's tokenizer for Latin-script locales, including by script subtag", async () => {
+    // The script, not the language, decides: Serbian in Latin script stays on
+    // the default tokenizer, and Azerbaijani in Cyrillic is segmented.
+    const latin = await buildOramaIndex(
+      [
+        {
+          content: "Ugovor o autorizaciji",
+          description: "",
+          locale: "sr-Latn",
+          route: "/sr",
+          title: "X",
+        },
+      ],
+      "sr-Latn"
+    );
+    expect(latin.tokenizer?.language).toBe("english");
+    const latinHits = await queryOramaIndex(latin, "autorizaciji", 5);
+    expect(latinHits.length).toBe(1);
+
+    const cyrillic = await buildOramaIndex(
+      [
+        {
+          content: "Müqavilə səlahiyyət",
+          description: "",
+          locale: "az-Cyrl",
+          route: "/az",
+          title: "X",
+        },
+      ],
+      "az-Cyrl"
+    );
+    expect(cyrillic.tokenizer?.language).toBe("az");
+  });
+
+  it("falls back to Orama's tokenizer for locales ICU resolves no script for", async () => {
+    // An unparseable tag throws inside `Intl.Locale`, and a well-formed tag
+    // ICU knows nothing about resolves to no script; neither may break search.
+    const doc = {
+      content: "Authorization contract",
+      description: "",
+      locale: "en",
+      route: "/x",
+      title: "X",
+    };
+    const unknown = await buildOramaIndex([doc], "xx");
+    const malformed = await buildOramaIndex([doc], "not a locale");
+    const hits = await Promise.all([
+      queryOramaIndex(unknown, "authorization", 5),
+      queryOramaIndex(malformed, "authorization", 5),
+    ]);
+    expect(hits.map((found) => found.length)).toEqual([1, 1]);
+  });
+
   it("segments Chinese, Korean, and Thai content too", async () => {
     const cases = [
       { content: "修改搜索设置。", locale: "zh-Hans", term: "搜索" },

--- a/packages/blume/test/mcp.test.ts
+++ b/packages/blume/test/mcp.test.ts
@@ -784,7 +784,7 @@ describe("orama index helpers", () => {
     const cyrillic = await buildOramaIndex(
       [
         {
-          content: "Müqavilə səlahiyyət",
+          content: "Мүгавилә сәлаһијјәт",
           description: "",
           locale: "az-Cyrl",
           route: "/az",
@@ -794,6 +794,8 @@ describe("orama index helpers", () => {
       "az-Cyrl"
     );
     expect(cyrillic.tokenizer?.language).toBe("az");
+    const cyrillicHits = await queryOramaIndex(cyrillic, "сәлаһијјәт", 5);
+    expect(cyrillicHits.length).toBe(1);
   });
 
   it("falls back to Orama's tokenizer for locales ICU resolves no script for", async () => {

--- a/packages/blume/test/mcp.test.ts
+++ b/packages/blume/test/mcp.test.ts
@@ -799,8 +799,9 @@ describe("orama index helpers", () => {
   });
 
   it("falls back to Orama's tokenizer for locales ICU resolves no script for", async () => {
-    // An unparseable tag throws inside `Intl.Locale`, and a well-formed tag
-    // ICU knows nothing about resolves to no script; neither may break search.
+    // A well-formed tag ICU knows nothing about resolves to no script; a
+    // malformed tag throws but its primary subtag parses; a tag whose primary
+    // subtag is itself unparseable throws twice. None may break search.
     const doc = {
       content: "Authorization contract",
       description: "",
@@ -810,11 +811,99 @@ describe("orama index helpers", () => {
     };
     const unknown = await buildOramaIndex([doc], "xx");
     const malformed = await buildOramaIndex([doc], "not a locale");
+    const unparseable = await buildOramaIndex([doc], "€");
     const hits = await Promise.all([
       queryOramaIndex(unknown, "authorization", 5),
       queryOramaIndex(malformed, "authorization", 5),
+      queryOramaIndex(unparseable, "authorization", 5),
     ]);
-    expect(hits.map((found) => found.length)).toEqual([1, 1]);
+    expect(hits.map((found) => found.length)).toEqual([1, 1, 1]);
+  });
+
+  it("segments legacy POSIX and extlang locale tags by their language subtag", async () => {
+    // `ja_JP.UTF-8`-style tags copied from environment config and extlang
+    // forms like `zh-cmn-Hans` throw inside `Intl.Locale`, but the primary
+    // language subtag still resolves the script — these sites segmented
+    // before the script-based gate and must keep doing so.
+    const ja = {
+      content: "検索設定を変更します。",
+      description: "",
+      locale: "ja",
+      route: "/ja",
+      title: "X",
+    };
+    const zh = {
+      content: "修改搜索设置。",
+      description: "",
+      locale: "zh",
+      route: "/zh",
+      title: "X",
+    };
+    const posix = await buildOramaIndex([ja], "ja_JP.UTF-8");
+    expect(posix.tokenizer?.language).toBe("ja");
+    const posixHits = await queryOramaIndex(posix, "検索", 5);
+    expect(posixHits.length).toBe(1);
+    const extlang = await buildOramaIndex([zh], "zh-cmn-Hans");
+    expect(extlang.tokenizer?.language).toBe("zh");
+    const extlangHits = await queryOramaIndex(extlang, "搜索", 5);
+    expect(extlangHits.length).toBe(1);
+  });
+
+  it("bigrams Han-script languages beyond ja and zh, like Cantonese", async () => {
+    // The writing system, not the language subtag, carries the compound
+    // convention: `yue` maximizes to Hant and needs bigrams — and the strict
+    // query pass — the same way `zh` does. The fragments page shares the
+    // compound's parts but not its bigram windows, so the strict pass keeps
+    // it out entirely.
+    const fragments = {
+      content: "資金 決済 法",
+      description: "",
+      locale: "yue",
+      route: "/fragments",
+      title: "X",
+    };
+    const compound = {
+      content: "資金決済法の適用範囲",
+      description: "",
+      locale: "yue",
+      route: "/compound",
+      title: "X",
+    };
+    const db = await buildOramaIndex([fragments, compound], "yue");
+    expect(db.tokenizer?.language).toBe("yue");
+    const hits = await queryOramaIndex(db, "資金決済法", 5);
+    expect(hits.map((doc) => doc.route)).toEqual(["/compound"]);
+  });
+
+  it("folds Latin diacritics on a segmented index, keeping marks elsewhere", async () => {
+    // Orama's default tokenizer folds café → cafe; the segmenting tokenizer
+    // must not lose that on the Latin loanwords a non-Latin site mixes in.
+    // Marks stay everywhere else — й is not и plus a mark to strip.
+    const docs = [
+      {
+        content: "Встретимся в café",
+        description: "",
+        locale: "ru",
+        route: "/cafe",
+        title: "X",
+      },
+      {
+        content: "йогурт на завтрак",
+        description: "",
+        locale: "ru",
+        route: "/yogurt",
+        title: "X",
+      },
+    ];
+    const db = await buildOramaIndex(docs, "ru");
+    const unaccented = await queryOramaIndex(db, "cafe", 5);
+    expect(unaccented.map((doc) => doc.route)).toEqual(["/cafe"]);
+    const accented = await queryOramaIndex(db, "café", 5);
+    expect(accented.map((doc) => doc.route)).toEqual(["/cafe"]);
+    const stripped = await queryOramaIndex(db, "иогурт", 5);
+    expect(stripped.length).toBe(0);
+    const spelled = await queryOramaIndex(db, "йогурт", 5);
+    expect(spelled.map((doc) => doc.route)).toEqual(["/yogurt"]);
   });
 
   it("segments Chinese, Korean, and Thai content too", async () => {


### PR DESCRIPTION
## The bug

`buildOramaIndex` gives the segmenting tokenizer only to `ja`, `ko`, `th`, `zh`. Every other locale falls through to Orama's default tokenizer, whose delimiter class is `/[^A-Za-zàèéìòóù0-9_'-]+/` — so any character outside Latin is a separator, and the text collapses to zero tokens.

Spacing was never what broke tokenization. Russian, Greek, Hebrew and Hindi fail exactly the way Japanese did in #125: the index holds the content, every query returns nothing, and nothing errors — it reads as an empty index rather than a tokenizer mismatch.

Measured on a one-document index, querying a word from that document:

| locale | script | hits before | hits after |
| --- | --- | --- | --- |
| `ru` | Cyrl | 0 | 1 |
| `el` | Grek | 0 | 1 |
| `he` | Hebr | 0 | 1 |
| `hi` | Deva | 0 | 1 |
| `fr` | Latn | 1 | 1 |
| `en` | Latn | 1 | 1 |

I hit this on a Russian docs site: `blume-search.json` contained the Cyrillic content, and the dialog found nothing for any word in it.

## The change

Derive the script from `Intl.Locale.maximize()` rather than listing languages — a language list cannot be complete, and the script is what the tokenizer actually depends on. A bare tag resolves to its default script (`ru` → `Cyrl`), an explicit one is honored, so `sr-Latn` keeps Orama's tokenizer while `az-Cyrl` is segmented. Unparseable tags and tags ICU knows no script for keep the default tokenizer, which is what they already got.

Bigram indexing stays keyed to Japanese and Chinese; the CJK behavior from #132 and #178 is untouched. Underscored tags (`ru_RU`) are normalized before ICU sees them, since the old code split on `[-_]` and would otherwise regress.

## Notes

- Tests are in the existing `orama index helpers` block: one for spaced non-Latin scripts (asserting zero hits before segmentation and one after, so the guard fails if the tokenizer stops being selected), one for `sr-Latn` / `az-Cyrl`, and one for locales ICU resolves no script for. Reverting the fix fails the first two.
- Test inputs are rule-based rather than ICU-edge-dependent, per the `Intl.Segmenter` note in AGENTS.md.
- `bun run check`, `bun run typecheck` and `bun run test:coverage` pass; `packages/blume` stays at 100% line and function coverage.
- Docs: the search page's "Languages written without spaces" section is now "Non-Latin scripts". No other page linked that anchor.
- Changeset included as a patch.

Happy to narrow this to a plain `ru` entry in the old allow-list if you'd rather keep the explicit list — but greek, hebrew and devanagari sites would stay broken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved search support for non-Latin languages, including Cyrillic, Greek, Hebrew, Devanagari, and CJK scripts.
  - Search now selects appropriate text segmentation based on the configured locale, including legacy and malformed locale formats.
  - Mixed-language search is improved, with Latin diacritics normalized where appropriate.
  - Unknown or invalid locales continue to use standard search behavior.

- **Documentation**
  - Updated configuration guidance to describe broader non-Latin script support and tokenizer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->