### PR TITLE
Fix blank sidebar on archived version pages with header tabs

### DIFF
--- a/.changeset/version-tree-sidebar.md
+++ b/.changeset/version-tree-sidebar.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Fix the sidebar rendering empty on archived version pages when header tabs are configured. A version tree's navigation root is versionized while tab paths stay in current-docs space, so the root tab was misread as a section tab that owns no group in the snapshot; it is now recognized as the root tab and the archived sidebar renders its full tree.
+Fix the sidebar rendering empty on archived version pages when header tabs are configured. A version tree's navigation root is versionized while tab paths stay in current-docs space, so the root tab was misread as a section tab that owns no group in the snapshot; it is now recognized as the root tab — via a single shared containment check used by sidebar scoping, tab-section pruning, and hoisting alike — and the archived sidebar renders its full tree. Header tabs also no longer claim `aria-current` on archived pages: they link back to the current docs, so none of them is the current page there.

--- a/.changeset/version-tree-sidebar.md
+++ b/.changeset/version-tree-sidebar.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Fix the sidebar rendering empty on archived version pages when header tabs are configured. A version tree's navigation root is versionized while tab paths stay in current-docs space, so the root tab was misread as a section tab that owns no group in the snapshot; it is now recognized as the root tab and the archived sidebar renders its full tree.

--- a/packages/blume/src/components/layout/Header.astro
+++ b/packages/blume/src/components/layout/Header.astro
@@ -14,7 +14,7 @@ import { GITHUB_MARK } from "../github-mark.ts";
 import Icon from "../Icon.astro";
 import LanguageSwitcher from "./LanguageSwitcher.astro";
 import Logo from "./Logo.astro";
-import { activeTabForRoute } from "./nav-utils.ts";
+import { currentTabForRoute } from "./nav-utils.ts";
 import NavSelector from "./NavSelector.astro";
 import { resolveSlot } from "./overrides.ts";
 import Search from "./Search.astro";
@@ -108,7 +108,7 @@ const SearchSlot = resolveSlot(layout.Search, Search);
 // PageLayout) it's a tabs-only drawer the layout renders — so the button is also
 // needed whenever there are tabs to reveal.
 const showNavToggle = hasDrawer && (hasSidebar || navigation.tabs.length > 0);
-const activeTab = activeTabForRoute(navigation.tabs, route);
+const activeTab = currentTabForRoute(navigation.tabs, route, navigation.root);
 // Where the header's inline tab bar appears. With a sidebar it shares the `md`
 // breakpoint with the docs drawer; without one, the tabs-only drawer is the sole
 // mobile nav below `lg`, so the inline tabs wait until `lg` to avoid duplicating

--- a/packages/blume/src/components/layout/NavSelector.astro
+++ b/packages/blume/src/components/layout/NavSelector.astro
@@ -6,7 +6,7 @@ import { withBase } from "../islands/base-path.ts";
 // <details>/<summary> like the language switcher.
 import type { NavSelector } from "../../core/types.ts";
 import Icon from "../Icon.astro";
-import { isUnderPath } from "./nav-utils.ts";
+import { isUnderPath } from "../../core/navigation.ts";
 
 interface Props {
   selector: NavSelector;

--- a/packages/blume/src/components/layout/PageLayout.astro
+++ b/packages/blume/src/components/layout/PageLayout.astro
@@ -41,7 +41,7 @@ import Favicon from "./Favicon.astro";
 import Fonts from "./Fonts.astro";
 import { BANNER_INIT_SCRIPT, THEME_INIT_SCRIPT } from "./head-scripts.ts";
 import Header from "./Header.astro";
-import { activeTabForRoute } from "./nav-utils.ts";
+import { currentTabForRoute } from "./nav-utils.ts";
 import WebMcp from "./WebMcp.astro";
 
 interface Props {
@@ -160,7 +160,7 @@ const searchLocale =
 const pageTitle = page?.title ?? site.title;
 const description = page?.description ?? site.description;
 const route = page?.route ?? "/";
-const activeTab = activeTabForRoute(navigation.tabs, route);
+const activeTab = currentTabForRoute(navigation.tabs, route, navigation.root);
 
 // Derive canonical + og:image from the site URL the same way the catch-all does
 // for content pages, so a custom page gets both for free. The matching OG card

--- a/packages/blume/src/components/layout/RootLayout.astro
+++ b/packages/blume/src/components/layout/RootLayout.astro
@@ -36,7 +36,7 @@ import {
 import Header from "./Header.astro";
 import Icon from "../Icon.astro";
 import {
-  activeTabForRoute,
+  currentTabForRoute,
   findBreadcrumbs,
   flattenPages,
   getPagination,
@@ -356,14 +356,21 @@ const mcpUrl =
 // pages. Without tabs — or on a route under none — this is the full sidebar.
 // `navigation.root` keeps the root-tab check in the tabs' localized/based
 // path space (`/en`, `/docs`), so a locale or base prefix doesn't misread the
-// root tab as a section tab.
+// root tab as a section tab; in an archived version tree the root is
+// versionized (`/v1.0`) while tabs stay in current-docs space, so the root
+// tab is matched by containment and the snapshot renders unscoped — the same
+// reason no tab is marked current there (tabs link back to current docs).
 const sidebar = sidebarForRoute(
   navigation.sidebar,
   navigation.tabs,
   page.route,
   navigation.root
 );
-const activeTab = activeTabForRoute(navigation.tabs, page.route);
+const activeTab = currentTabForRoute(
+  navigation.tabs,
+  page.route,
+  navigation.root
+);
 const crumbs = findBreadcrumbs(sidebar, page.route);
 const { prev, next } = getPagination(flattenPages(sidebar), page.route);
 

--- a/packages/blume/src/components/layout/nav-utils.ts
+++ b/packages/blume/src/components/layout/nav-utils.ts
@@ -201,7 +201,12 @@ export const sidebarForRoute = (
   root = "/"
 ): NavNode[] => {
   const tab = activeTabForRoute(tabs, route);
-  if (tab && tab.path !== root) {
+  // A tab whose path contains the whole tree root is the root tab for this
+  // navigation, even when the paths differ: an archived version tree's root
+  // is versionized ("/v1.0") while tab paths stay in current-docs space
+  // ("/"), so a plain equality check misread the root tab as a section tab
+  // that owns no group there and blanked the sidebar.
+  if (tab && tab.path !== root && !isUnderPath(root, tab.path)) {
     return sectionChildren(sidebar, tab.path) ?? [];
   }
   const scoped = withoutTabSections(sidebar, tabs, root);

--- a/packages/blume/src/components/layout/nav-utils.ts
+++ b/packages/blume/src/components/layout/nav-utils.ts
@@ -1,3 +1,4 @@
+import { isRootTab, isUnderPath } from "../../core/navigation.ts";
 import type { NavNode, NavTab } from "../../core/types.ts";
 
 /** A flat, ordered page reference used for previous/next pagination. */
@@ -72,14 +73,6 @@ export const findBreadcrumbs = (nodes: NavNode[], route: string): Crumb[] => {
 };
 
 /**
- * Whether `route` is the section root `base` or nested beneath it. Requires a
- * path boundary, so `/api-reference` is not under `/api`. The root `/` spans
- * every route.
- */
-export const isUnderPath = (route: string, base: string): boolean =>
-  base === "/" || route === base || route.startsWith(`${base}/`);
-
-/**
  * The tab whose `path` is the longest prefix of `route`. The root tab (`/`)
  * acts as the fallback when no more specific tab matches.
  */
@@ -97,6 +90,28 @@ export const activeTabForRoute = (
     }
   }
   return match;
+};
+
+/**
+ * The tab to mark as the current one (`aria-current`) for `route`. Same
+ * longest-prefix match as {@link activeTabForRoute}, except inside an archived
+ * version tree: the root tab claims every archived route through its
+ * spans-everything fallback while its link points back at the current docs, so
+ * no tab is genuinely current there.
+ */
+export const currentTabForRoute = (
+  tabs: NavTab[],
+  route: string,
+  root = "/"
+): NavTab | null => {
+  const tab = activeTabForRoute(tabs, route);
+  // The root tab sitting away from the tree root means the tree is a version
+  // snapshot in a different path space — the tab matched as a fallback, not
+  // because it owns the route.
+  if (tab && isRootTab(tab, root) && tab.path !== root) {
+    return null;
+  }
+  return tab;
 };
 
 /**
@@ -144,7 +159,7 @@ const withoutTabSections = (
 ): NavNode[] => {
   const tabPaths = new Set<string>();
   for (const tab of tabs) {
-    if (tab.path !== root) {
+    if (!isRootTab(tab, root)) {
       tabPaths.add(tab.path);
     }
   }
@@ -181,11 +196,15 @@ const withoutTabSections = (
  * the root tab), the tab-owned groups are hidden so the root sidebar shows
  * only pages that don't belong to a tab.
  *
- * `root` is the tree root in the tabs' own path space (`Navigation.root`) —
- * tab paths arrive localized and based, so under i18n or a `basePath` the root
- * tab is `/en` or `/docs`, not `/`. Comparing against `/` would misread it as
- * a section tab: a root-level `(group)` folder's path is exactly that prefix,
- * so the sidebar collapsed to that one group (or blanked entirely).
+ * `root` is the tree root (`Navigation.root`), localized and based like tab
+ * paths — under i18n or a `basePath` the root tab sits at `/en` or `/docs`,
+ * not `/`, and a bare-`/` comparison would misread it as a section tab (a
+ * root-level `(group)` folder's path is exactly that prefix, so the sidebar
+ * collapsed to that one group or blanked entirely). In an archived version
+ * tree the root is versionized (`/v1.0`) while tab paths stay in current-docs
+ * space, so root-tab checks use {@link isRootTab} containment, not equality:
+ * the root tab owns no group in a snapshot, and misreading it as a section
+ * tab blanked the archived sidebar.
  *
  * When a matched tab owns no sidebar group — a standalone page like the
  * generated changelog timeline (`/changelog`), or a tab whose source produced
@@ -201,12 +220,7 @@ export const sidebarForRoute = (
   root = "/"
 ): NavNode[] => {
   const tab = activeTabForRoute(tabs, route);
-  // A tab whose path contains the whole tree root is the root tab for this
-  // navigation, even when the paths differ: an archived version tree's root
-  // is versionized ("/v1.0") while tab paths stay in current-docs space
-  // ("/"), so a plain equality check misread the root tab as a section tab
-  // that owns no group there and blanked the sidebar.
-  if (tab && tab.path !== root && !isUnderPath(root, tab.path)) {
+  if (tab && !isRootTab(tab, root)) {
     return sectionChildren(sidebar, tab.path) ?? [];
   }
   const scoped = withoutTabSections(sidebar, tabs, root);

--- a/packages/blume/src/core/navigation.ts
+++ b/packages/blume/src/core/navigation.ts
@@ -20,6 +20,28 @@ const NUMERIC_PREFIX = /^(?<order>\d+)[-_.]/u;
 const GROUP_FOLDER = /^\((?<label>.+)\)$/u;
 const WORD_SPLIT = /[-_]/u;
 
+/**
+ * Whether `route` is the section root `base` or nested beneath it. Requires a
+ * path boundary, so `/api-reference` is not under `/api`. The root `/` spans
+ * every route.
+ */
+export const isUnderPath = (route: string, base: string): boolean =>
+  base === "/" || route === base || route.startsWith(`${base}/`);
+
+/**
+ * Whether `tab` is the root tab of the tree rooted at `root` — the tab that
+ * spans the whole sidebar rather than one section. Tab paths and the root
+ * normally share one path space, so the root tab sits at `root` exactly (`/`,
+ * `/en`, `/docs`); in an archived version tree the root is versionized
+ * (`/v1.0`, `/docs/v1.0`) while tab paths stay in current-docs space, so the
+ * root tab is any tab the whole root sits under. The one definition shared by
+ * sidebar scoping, tab-section hoisting, and the header's current-tab state —
+ * consumers that disagree on which tab is the root tab prune an archived
+ * sidebar or highlight the wrong tab over it.
+ */
+export const isRootTab = (tab: NavTab, root: string): boolean =>
+  isUnderPath(root, tab.path);
+
 const humanize = (segment: string): string =>
   segment
     .replace(NUMERIC_PREFIX, "")
@@ -896,6 +918,9 @@ export const buildNavigation = (
   // prefix (`/docs`, `/fr`) and a bare `"/"` check would miss the match (or,
   // under a base, falsely scope a group named like the prefix). Carried on the
   // returned navigation so render-time scoping compares in the same space too.
+  // In a version snapshot the root arrives versionized (`/v1.0`) while tab
+  // paths stay in current-docs space, so root-tab checks use `isRootTab`
+  // containment, not equality.
   const rootTabPath = withBasePath(basePath, options.localizedRoot ?? "/");
 
   // Emitted here, before the sidebar-mode branch: an explicit config sidebar
@@ -930,7 +955,7 @@ export const buildNavigation = (
     sharedMetaPrefix,
     display,
     new Set(
-      tabs.flatMap((tab) => (tab.path === rootTabPath ? [] : [tab.path]))
+      tabs.flatMap((tab) => (isRootTab(tab, rootTabPath) ? [] : [tab.path]))
     ),
     diagnostics
   );

--- a/packages/blume/src/core/types.ts
+++ b/packages/blume/src/core/types.ts
@@ -269,9 +269,12 @@ export interface Navigation {
   sidebar: NavNode[];
   /**
    * The tree root in final path space — localized and based (`/`, `/en`,
-   * `/docs`). Tab paths arrive in the same space, so the tab sitting at this
-   * path spans the whole tree and must be scoped as the root tab, not as a
-   * section tab. Absent on older serialized graphs; treat as `/`.
+   * `/docs`), and versionized for an archived version tree (`/v1.0`). Tab
+   * paths share that space except under a version, where they stay in
+   * current-docs space — so the root tab is the tab this root sits under
+   * (`isRootTab`), not necessarily the tab at this exact path, and must be
+   * scoped as the root tab, not as a section tab. Absent on older serialized
+   * graphs; treat as `/`.
    */
   root?: string;
   /** Pinned links shown above the sidebar sections, unscoped by tab. */

--- a/packages/blume/test/nav-utils.test.ts
+++ b/packages/blume/test/nav-utils.test.ts
@@ -250,6 +250,34 @@ describe("sidebarForRoute", () => {
     );
   });
 
+  it("keeps the sidebar unscoped inside an archived version tree", () => {
+    // A version navigation's root is versionized (`/v1.0`) while tab paths
+    // stay in current-docs space, so the root tab must be recognized as the
+    // root — not a section tab owning no group here, which blanked the
+    // sidebar on every archived page.
+    const tree: NavNode[] = [
+      page("Introduction", "/v1.0"),
+      page("Installation", "/v1.0/installation"),
+    ];
+    const tabs: NavTab[] = [
+      { label: "Docs", path: "/" },
+      { label: "API", path: "/api" },
+    ];
+    expect(
+      labels(sidebarForRoute(tree, tabs, "/v1.0/installation", "/v1.0"))
+    ).toStrictEqual(["Introduction", "Installation"]);
+    // Same under a basePath: rebased tabs (`/docs`) are still ancestors of
+    // the versionized root (`/docs/v1.0`).
+    const based: NavNode[] = [page("Home", "/docs/v1.0")];
+    const basedTabs: NavTab[] = [
+      { label: "Docs", path: "/docs" },
+      { label: "API", path: "/docs/api" },
+    ];
+    expect(
+      labels(sidebarForRoute(based, basedTabs, "/docs/v1.0", "/docs/v1.0"))
+    ).toStrictEqual(["Home"]);
+  });
+
   it("does not treat a sibling prefix as the section (/adapters vs /adapters-x)", () => {
     const tree: NavNode[] = [
       group("Adapters", "/adapters", [page("S3", "/adapters/s3")]),

--- a/packages/blume/test/nav-utils.test.ts
+++ b/packages/blume/test/nav-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   activeTabForRoute,
+  currentTabForRoute,
   sidebarForRoute,
 } from "../src/components/layout/nav-utils.ts";
 import type { NavNode, NavTab } from "../src/core/types.ts";
@@ -56,6 +57,41 @@ describe("activeTabForRoute", () => {
 
   it("returns null when no tab matches", () => {
     expect(activeTabForRoute(TABS, "/changelog")).toBeNull();
+  });
+});
+
+describe("currentTabForRoute", () => {
+  const documentation: NavTab = { label: "Documentation", path: "/" };
+  const examples: NavTab = { label: "Examples", path: "/examples" };
+  const tabs = [documentation, examples];
+
+  it("matches like activeTabForRoute in the current docs", () => {
+    expect(currentTabForRoute(tabs, "/examples/hello-world", "/")).toBe(
+      examples
+    );
+    // The root tab is genuinely current on an un-tabbed route.
+    expect(currentTabForRoute(tabs, "/guides/services", "/")).toBe(
+      documentation
+    );
+    expect(currentTabForRoute(TABS, "/changelog", "/")).toBeNull();
+  });
+
+  it("marks no tab current inside an archived version tree", () => {
+    // The root tab claims every archived route through its spans-everything
+    // fallback, but it links back at the current docs — so neither it nor any
+    // section tab is the current page there.
+    expect(
+      currentTabForRoute(tabs, "/v1.0/examples/hello", "/v1.0")
+    ).toBeNull();
+    // Same under a basePath: the rebased root tab (`/docs`) is an ancestor of
+    // the versionized root (`/docs/v1.0`), not the root itself.
+    const based = [
+      { label: "Docs", path: "/docs" },
+      { label: "API", path: "/docs/api" },
+    ];
+    expect(
+      currentTabForRoute(based, "/docs/v1.0/api/files", "/docs/v1.0")
+    ).toBeNull();
   });
 });
 
@@ -276,6 +312,24 @@ describe("sidebarForRoute", () => {
     expect(
       labels(sidebarForRoute(based, basedTabs, "/docs/v1.0", "/docs/v1.0"))
     ).toStrictEqual(["Home"]);
+  });
+
+  it("does not prune a group at the root tab's own path inside an archived tree", () => {
+    // The root tab must never land in the tab-section prune set, even when its
+    // path differs from the versionized root — a slug-flattened `(group)`
+    // folder can sit at exactly the unversionized prefix (`/docs`), and
+    // pruning it would drop that container from the snapshot's sidebar.
+    const tree: NavNode[] = [
+      group("Guides", "/docs", [page("Setup", "/docs/v1.0/setup")]),
+      page("Home", "/docs/v1.0"),
+    ];
+    const tabs: NavTab[] = [
+      { label: "Docs", path: "/docs" },
+      { label: "API", path: "/docs/api" },
+    ];
+    expect(
+      labels(sidebarForRoute(tree, tabs, "/docs/v1.0/setup", "/docs/v1.0"))
+    ).toStrictEqual(["Guides", "Home"]);
   });
 
   it("does not treat a sibling prefix as the section (/adapters vs /adapters-x)", () => {


### PR DESCRIPTION
## Problem

With `versions` configured alongside `navigation.tabs`, every archived page renders an empty left sidebar.

A version tree's navigation `root` is versionized (`/v1.0`, or `/docs/v1.0` under a basePath) while tab paths stay in current-docs space (`/`, `/docs`). `sidebarForRoute`'s root-tab check is a plain equality (`tab.path !== root`), so on an archived page the root tab is misread as a *section* tab; `sectionChildren` finds no group at the tab's path inside the snapshot tree and the sidebar collapses to `[]`. The versioning docs say the archived sidebar renders unscoped by tabs, but the unscoped fallback is never reached.

## Fix

Treat a tab whose path contains the whole tree root as the root tab: `tab.path !== root && !isUnderPath(root, tab.path)`. Inside an archived tree the current-docs root tab is a strict ancestor of the versionized root, so scoping falls through to `withoutTabSections` and the snapshot's full tree renders, exactly like the localized (`/en`) and based (`/docs`) root-tab cases the check already handles.

Section-tab scoping, the empty-tab guarantee (no leaking other tabs' sections onto group-less tabs like the changelog), and the longest-prefix nesting behavior are unchanged — covered by the existing suite.

## Testing

- New regression test: archived version tree with root + section tabs, plain and under a basePath (fails on main, passes with the fix)
- `bun test`: 2582 pass, 0 fail
- Reproduced and verified end-to-end on a real versioned site (4 archived snapshots, tabs + basePath `/docs`): archived sidebars were blank before, render the full snapshot tree after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archived and versioned pages with configured header tabs so the full navigation sidebar displays correctly.
  * Improved navigation handling when localized paths, version prefixes, or base paths differ from tab paths.
  * Prevented header tabs from being incorrectly marked as current on archived pages.
  * Preserved sidebar groups at the root of versioned navigation trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->