### PR TITLE
feat: ts2js fences render synced TypeScript/JavaScript tabs

### DIFF
--- a/.changeset/tabs-sync-key-scoped-panels.md
+++ b/.changeset/tabs-sync-key-scoped-panels.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Add a `syncKey` prop to `Tabs`: only groups sharing the same key switch together, so unrelated groups that happen to share a tab title stay independent. Nested tab groups now also keep their own panels instead of having them adopted by an ancestor group.

--- a/.changeset/ts2js-code-tabs.md
+++ b/.changeset/ts2js-code-tabs.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Add `ts2js` code fences: mark a `ts` or `tsx` block with the `ts2js` meta keyword and it renders as synced TypeScript/JavaScript tabs, with the JavaScript variant generated automatically — type syntax and type-only imports stripped, formatting, comments, and JSX preserved.

--- a/apps/docs/content/docs/content/components.mdx
+++ b/apps/docs/content/docs/content/components.mdx
@@ -71,6 +71,8 @@ Switch between equivalent content in place — language variants, OS-specific co
 
 Add `inline` to render borderless — a tab strip on a full-width rule with the content flowing beneath as prose — instead of the bordered box. Add `param` to sync the active tab to a URL query param instead of the hash, which makes the selection shareable: a link ending in `?install=windows` opens on the Windows tab. Each group syncs to its own `param`, so you can use several independent, deep-linkable groups on one page.
 
+Groups with same-titled tabs switch together — pick "macOS" in one and every group with a macOS tab follows. Add `syncKey` to scope that syncing: only groups sharing the same key switch together, so unrelated groups that happen to share a tab title stay independent.
+
 <Tabs inline param="install">
   <Tab title="macOS">Use Homebrew to install the toolchain.</Tab>
   <Tab title="Windows">Use winget to install the toolchain.</Tab>

--- a/apps/docs/content/docs/content/syntax.mdx
+++ b/apps/docs/content/docs/content/syntax.mdx
@@ -285,6 +285,42 @@ config.title;
 ```
 ````
 
+### TypeScript and JavaScript tabs
+
+Mark a `ts` or `tsx` block `ts2js` to render it as a tab pair: your TypeScript alongside an auto-generated JavaScript variant, so you maintain one snippet and readers pick their dialect. The conversion strips type syntax and type-only imports while keeping your formatting, comments, and JSX exactly as written — and tabs sync, so choosing JavaScript once switches every pair on the page. Like diagrams and math, this is an MDX-only feature — in a `.md` file the block renders as a plain TypeScript fence.
+
+```ts ts2js
+import { defineConfig } from "blume";
+
+interface Author {
+  name: string;
+}
+
+const author: Author = { name: "Hayden" };
+
+export default defineConfig({
+  title: `${author.name}'s docs`,
+});
+```
+
+````md
+```ts ts2js
+import { defineConfig } from "blume";
+
+interface Author {
+  name: string;
+}
+
+const author: Author = { name: "Hayden" };
+
+export default defineConfig({
+  title: `${author.name}'s docs`,
+});
+```
+````
+
+Other fence meta composes: a `title="..."` shows on both tabs, while `{1,4-5}` line ranges apply only to the TypeScript tab (line numbers shift once types are gone). The one exception is `twoslash` — hover types can't carry over to generated code, so a fence marked both stays a plain Twoslash block.
+
 :::note
 Hide the language icons or wrap long lines instead of scrolling with `markdown: { code: { icons: false, wrap: true } }` in `blume.config.ts`.
 :::

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "packages/blume": {
       "name": "blume",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "bin": {
         "blume": "bin/blume.mjs",
       },
@@ -139,6 +139,7 @@
         "shiki": "^4.2.0",
         "simple-icons": "^13.0.0",
         "string-width": "^8.1.0",
+        "sucrase": "^3.35.1",
         "tailwindcss": "^4.3.3",
         "takumi-js": "^2.2.1",
         "tinyglobby": "^0.2.10",
@@ -1337,6 +1338,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
@@ -2369,6 +2372,8 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanotar": ["nanotar@0.3.0", "", {}, "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg=="],
@@ -2518,6 +2523,8 @@
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -2797,6 +2804,8 @@
 
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
@@ -2820,6 +2829,10 @@
     "terser": ["terser@5.49.2", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ=="],
 
     "terser-webpack-plugin": ["terser-webpack-plugin@5.6.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "terser": "^5.31.1" }, "peerDependencies": { "@minify-html/node": "*", "@swc/core": "*", "@swc/css": "*", "@swc/html": "*", "clean-css": "*", "cssnano": "*", "csso": "*", "esbuild": "*", "html-minifier-terser": "*", "lightningcss": "*", "postcss": "*", "uglify-js": "*", "webpack": "^5.1.0" }, "optionalPeers": ["@minify-html/node", "@swc/core", "@swc/css", "@swc/html", "clean-css", "cssnano", "csso", "esbuild", "html-minifier-terser", "lightningcss", "postcss", "uglify-js"] }, "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "through2": ["through2@4.0.2", "", { "dependencies": { "readable-stream": "3" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
 
@@ -2850,6 +2863,8 @@
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -3199,6 +3214,8 @@
 
     "astro/get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
+    "blume/@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.7", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.10.3" } }, "sha512-NHcHbrKW/opbZnTZQ5nH293BdcK2VV0tjuzI88CLnvy2njiEJVwUQ5KFnYd4NoWgHJCY/I1CyjGWCR4Vv3khXQ=="],
+
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -3294,6 +3311,8 @@
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -3483,6 +3502,10 @@
 
     "astro/@astrojs/markdown-satteri/satteri": ["satteri@0.10.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.5", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.10.5", "@bruits/satteri-darwin-x64": "0.10.5", "@bruits/satteri-linux-arm64-gnu": "0.10.5", "@bruits/satteri-linux-arm64-musl": "0.10.5", "@bruits/satteri-linux-x64-gnu": "0.10.5", "@bruits/satteri-linux-x64-musl": "0.10.5", "@bruits/satteri-wasm32-wasi": "0.10.5", "@bruits/satteri-win32-arm64-msvc": "0.10.5", "@bruits/satteri-win32-x64-msvc": "0.10.5" } }, "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ=="],
 
+    "blume/@astrojs/markdown-satteri/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.4", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA=="],
+
+    "blume/@astrojs/markdown-satteri/satteri": ["satteri@0.10.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.5", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.10.5", "@bruits/satteri-darwin-x64": "0.10.5", "@bruits/satteri-linux-arm64-gnu": "0.10.5", "@bruits/satteri-linux-arm64-musl": "0.10.5", "@bruits/satteri-linux-x64-gnu": "0.10.5", "@bruits/satteri-linux-x64-musl": "0.10.5", "@bruits/satteri-wasm32-wasi": "0.10.5", "@bruits/satteri-win32-arm64-msvc": "0.10.5", "@bruits/satteri-win32-x64-msvc": "0.10.5" } }, "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ=="],
+
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
@@ -3585,6 +3608,24 @@
 
     "astro/@astrojs/markdown-satteri/satteri/@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.10.5", "", { "os": "win32", "cpu": "x64" }, "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ=="],
 
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.10.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-darwin-x64": ["@bruits/satteri-darwin-x64@0.10.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-arm64-gnu": ["@bruits/satteri-linux-arm64-gnu@0.10.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-arm64-musl": ["@bruits/satteri-linux-arm64-musl@0.10.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-x64-gnu": ["@bruits/satteri-linux-x64-gnu@0.10.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-x64-musl": ["@bruits/satteri-linux-x64-musl@0.10.5", "", { "os": "linux", "cpu": "x64" }, "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-wasm32-wasi": ["@bruits/satteri-wasm32-wasi@0.10.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.2.3" }, "cpu": "none" }, "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-win32-arm64-msvc": ["@bruits/satteri-win32-arm64-msvc@0.10.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.10.5", "", { "os": "win32", "cpu": "x64" }, "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ=="],
+
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "node-html-parser/css-select/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -3596,6 +3637,8 @@
     "@tailwindcss/webpack/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "astro/@astrojs/markdown-satteri/satteri/@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" } }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
 
     "node-html-parser/css-select/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 

--- a/packages/blume/package.json
+++ b/packages/blume/package.json
@@ -136,6 +136,7 @@
     "shiki": "^4.2.0",
     "simple-icons": "^13.0.0",
     "string-width": "^8.1.0",
+    "sucrase": "^3.35.1",
     "tailwindcss": "^4.3.3",
     "takumi-js": "^2.2.1",
     "tinyglobby": "^0.2.10",

--- a/packages/blume/src/components/content/Tabs.astro
+++ b/packages/blume/src/components/content/Tabs.astro
@@ -19,6 +19,13 @@ interface Props {
    */
   param?: string;
   sync?: boolean;
+  /**
+   * Sync tab selection only with other groups sharing the same key. Groups
+   * without a key form one page-wide pool (the default); keyed groups — like
+   * the generated ts2js dialect pairs — sync among themselves, so picking a
+   * tab there can't drag along an authored group with a same-titled tab.
+   */
+  syncKey?: string;
 }
 
 const {
@@ -29,6 +36,7 @@ const {
   inline = false,
   param,
   sync = true,
+  syncKey,
 } = Astro.props;
 
 // MDX string attributes (`hash="false"` from generated markup) must read as
@@ -52,6 +60,7 @@ const useDropdown = dropdown && !inline;
   data-hash={hashEnabled ? "true" : "false"}
   data-param={param}
   data-sync={sync ? "true" : "false"}
+  data-sync-key={syncKey}
 >
   <div
     class:list={[
@@ -116,9 +125,12 @@ const useDropdown = dropdown && !inline;
 
     connectedCallback() {
       const list = this.querySelector<HTMLElement>("[data-blume-tablist]");
+      // Nested groups (a generated ts2js pair inside a CodeGroup, say) own
+      // their panels; adopting a descendant group's panels here would leave
+      // both groups toggling the same elements.
       let panels = Array.from(
         this.querySelectorAll<HTMLElement>("[data-blume-tab-panel]")
-      );
+      ).filter((panel) => panel.closest("blume-tabs") === this);
       // CodeGroup passes raw code fences instead of <Tab> elements, so adopt
       // the content wrapper's direct code blocks as panels. The tab label comes
       // from each block's title (the text after the language in the fence).
@@ -251,7 +263,10 @@ const useDropdown = dropdown && !inline;
       if (sync && this.#syncEnabled()) {
         document.dispatchEvent(
           new CustomEvent(SYNC_EVENT, {
-            detail: { title: panelTitle(activePanel, index) },
+            detail: {
+              key: this.#syncKey(),
+              title: panelTitle(activePanel, index),
+            },
           })
         );
       }
@@ -339,6 +354,10 @@ const useDropdown = dropdown && !inline;
       return this.dataset.sync !== "false";
     }
 
+    #syncKey() {
+      return this.dataset.syncKey ?? "";
+    }
+
     #hashEnabled() {
       return this.dataset.hash !== "false";
     }
@@ -358,9 +377,12 @@ const useDropdown = dropdown && !inline;
     }
 
     #sync = (event: Event) => {
-      const title = (event as CustomEvent<{ title?: string }>).detail?.title;
-      if (title) {
-        this.activateByTitle(title, false);
+      const detail = (event as CustomEvent<{ key?: string; title?: string }>)
+        .detail;
+      // Only same-key groups sync: keyless groups form one page-wide pool,
+      // keyed groups (generated dialect pairs) their own.
+      if (detail?.title && (detail.key ?? "") === this.#syncKey()) {
+        this.activateByTitle(detail.title, false);
       }
     };
 

--- a/packages/blume/src/markdown/code-title.ts
+++ b/packages/blume/src/markdown/code-title.ts
@@ -39,12 +39,12 @@ const withoutQuotedAttrs = (raw: string): string =>
 
 // The first bare token is the title (```ts blume.config.ts): a non-empty token
 // that isn't a Shiki line range (`{1,3-5}`), a `key=value` attr, or a reserved
-// `lineNumbers`/`twoslash` keyword.
+// `lineNumbers`/`twoslash`/`ts2js` keyword.
 const isTitleToken = (token: string): boolean => {
   if (token.length === 0 || token.startsWith("{") || token.includes("=")) {
     return false;
   }
-  return token !== "lineNumbers" && token !== "twoslash";
+  return token !== "lineNumbers" && token !== "twoslash" && token !== "ts2js";
 };
 
 const parseTitle = (raw: string | undefined): string | undefined => {

--- a/packages/blume/src/markdown/code-title.ts
+++ b/packages/blume/src/markdown/code-title.ts
@@ -9,6 +9,12 @@
  *   `data-line-numbers`; the theme renders a counter-driven line-number gutter.
  */
 
+import {
+  isLineRange,
+  QUOTED_ATTR,
+  RESERVED_META_KEYWORDS,
+} from "./fence-meta.ts";
+
 /** The slice of Shiki's transformer `this` context Blume reads. */
 interface CodeMetaContext {
   options: { meta?: { __raw?: string } };
@@ -25,27 +31,22 @@ export interface CodeTitleTransformer {
   pre: (this: CodeMetaContext, node: PreNode) => void;
 }
 
-// The body excludes only the delimiting quote, so `title="foo's file.ts"`
-// (an apostrophe inside double quotes) still matches. The left boundary stops
-// `subtitle="..."` (or any `*title=` attr) from reading as a title.
 const TITLE_ATTR = /(?:^|\s)title=(?:"(?<dq>[^"]*)"|'(?<sq>[^']*)')/u;
 const LINE_NUMBERS = /(?:^|\s)lineNumbers(?=\s|$)/u;
-// Any quoted `key="..."` attr — blanked before keyword/bare-token scans so a
-// quoted value can't leak tokens (`title="enable lineNumbers later"`).
-const QUOTED_ATTR = /[\w-]+=(?:"[^"]*"|'[^']*')/gu;
 
+// Quoted attrs are blanked before keyword/bare-token scans so a quoted value
+// can't leak tokens (`title="enable lineNumbers later"`).
 const withoutQuotedAttrs = (raw: string): string =>
   raw.replace(QUOTED_ATTR, " ");
 
 // The first bare token is the title (```ts blume.config.ts): a non-empty token
 // that isn't a Shiki line range (`{1,3-5}`), a `key=value` attr, or a reserved
-// `lineNumbers`/`twoslash`/`ts2js` keyword.
-const isTitleToken = (token: string): boolean => {
-  if (token.length === 0 || token.startsWith("{") || token.includes("=")) {
-    return false;
-  }
-  return token !== "lineNumbers" && token !== "twoslash" && token !== "ts2js";
-};
+// keyword.
+const isTitleToken = (token: string): boolean =>
+  token.length > 0 &&
+  !isLineRange(token) &&
+  !token.includes("=") &&
+  !RESERVED_META_KEYWORDS.has(token);
 
 const parseTitle = (raw: string | undefined): string | undefined => {
   if (!raw) {

--- a/packages/blume/src/markdown/fence-meta.ts
+++ b/packages/blume/src/markdown/fence-meta.ts
@@ -1,0 +1,39 @@
+/**
+ * The shared fence-meta grammar: how the tokens after a code fence's language
+ * (```ts title="..." {1,3-5} lineNumbers) split, and which of them carry
+ * reserved meaning. Both the Shiki-side meta reader (`code-title.ts`) and the
+ * MDAST plugins that rewrite marked fences (`ts2js.ts`) consume this, so the
+ * two layers can't drift on token boundaries or keyword lists.
+ */
+
+/**
+ * Any quoted `key="..."` attr (spaces allowed inside the quotes). The body
+ * excludes only the delimiting quote, so `title="foo's file.ts"` (an
+ * apostrophe inside double quotes) still matches. The left boundary stops
+ * `subtitle="..."` (or any `*title=` attr) from reading as a title.
+ */
+export const QUOTED_ATTR = /[\w-]+=(?:"[^"]*"|'[^']*')/gu;
+
+/**
+ * One fence-meta token: a quoted attribute or a bare word, so a keyword
+ * inside a quoted value (`title="enable ts2js later"`) never reads as a
+ * bare token.
+ */
+const META_TOKEN = new RegExp(`${QUOTED_ATTR.source}|\\S+`, "gu");
+
+/** Split a raw fence meta string into its tokens. */
+export const metaTokens = (meta: string | null | undefined): string[] =>
+  meta?.match(META_TOKEN) ?? [];
+
+/**
+ * Bare keywords with reserved meaning after the language; never promoted to
+ * a block title.
+ */
+export const RESERVED_META_KEYWORDS: ReadonlySet<string> = new Set([
+  "lineNumbers",
+  "ts2js",
+  "twoslash",
+]);
+
+/** A Shiki `{1,3-5}` line-range token. */
+export const isLineRange = (token: string): boolean => token.startsWith("{");

--- a/packages/blume/src/markdown/index.ts
+++ b/packages/blume/src/markdown/index.ts
@@ -21,6 +21,7 @@ import { packageInstallPlugin } from "./package-install.ts";
 import { tableWrapPlugin } from "./table-wrap.ts";
 import { DEFAULT_CODE_THEMES } from "./themes.ts";
 import type { CodeThemes } from "./themes.ts";
+import { ts2jsPlugin } from "./ts2js.ts";
 
 export type { CodeTheme, CodeThemes } from "./themes.ts";
 
@@ -40,6 +41,7 @@ export { calloutTypeFor } from "./directives.ts";
 export { headingAnchorPlugin } from "./heading-anchors.ts";
 export { mermaidPlugin } from "./mermaid.ts";
 export { packageInstallPlugin } from "./package-install.ts";
+export { ts2jsPlugin } from "./ts2js.ts";
 export { blumeTwoslashTransformer } from "./twoslash.ts";
 
 /** Element type of Satteri's `mdastPlugins`, sourced from the (alpha) core. */
@@ -303,8 +305,9 @@ export type BlumeMdxOptions = BlumeMarkdownOptions;
 
 /**
  * Sätteri MDX processor: Blume's feature set plus the MDAST plugins that target
- * components — `package-install` → package-manager tabs, `:::note` →
- * `<Callout>`, ` ```mermaid ` → a `<blume-mermaid>` element, and block math
+ * components — `package-install` → package-manager tabs, ` ```ts ts2js ` →
+ * TypeScript/JavaScript tabs, `:::note` → `<Callout>`, ` ```mermaid ` → a
+ * `<blume-mermaid>` element, and block math
  * (`$$…$$`) → the `<Math>` component. Used as the `processor` for
  * `@astrojs/mdx` so these apply to `.mdx` only (plain `.md` uses
  * {@link blumeMarkdownProcessor}).
@@ -328,6 +331,7 @@ export const blumeMdxProcessor = (options: BlumeMdxOptions = {}) =>
     hastPlugins: blumeHastPlugins(options),
     mdastPlugins: [
       asMdastPlugin(packageInstallPlugin()),
+      asMdastPlugin(ts2jsPlugin()),
       asMdastPlugin(directiveToCalloutPlugin()),
       asMdastPlugin(mermaidPlugin()),
       asMdastPlugin(mathPlugin()),

--- a/packages/blume/src/markdown/mdast.ts
+++ b/packages/blume/src/markdown/mdast.ts
@@ -53,10 +53,14 @@ export const jsxTextElement = (
   children: MdastValue[] = []
 ) => ({ attributes, children, name, type: "mdxJsxTextElement" });
 
-/** Build a fenced code block node. */
-export const codeBlock = (lang: string, value: string) => ({
+/** Build a fenced code block node, optionally with a fence-meta string. */
+export const codeBlock = (
+  lang: string,
+  value: string,
+  meta: string | null = null
+) => ({
   lang,
-  meta: null,
+  meta,
   type: "code",
   value,
 });

--- a/packages/blume/src/markdown/ts2js.ts
+++ b/packages/blume/src/markdown/ts2js.ts
@@ -2,23 +2,23 @@
  * Satteri MDAST plugin that turns a TypeScript fence carrying the `ts2js`
  * meta keyword (```ts ts2js) into a `<Tabs>` group with the original
  * TypeScript and an auto-generated JavaScript variant, so authors maintain
- * one snippet and readers pick their dialect. Tab sync is on by default, so
- * every TypeScript/JavaScript group on a page switches together.
+ * one snippet and readers pick their dialect. The pair carries its own
+ * `syncKey`, so every ts2js pair on a page switches together without
+ * dragging along authored tab groups that happen to contain a tab titled
+ * "JavaScript".
  *
  * Types are stripped with Sucrase rather than the TypeScript compiler:
  * `ts.transpileModule` re-prints the file (collapsed blank lines, four-space
  * indentation, a `"use strict"` prologue on import-less snippets), while
  * Sucrase erases type syntax token-by-token and leaves the author's
- * formatting — including comments, and with them Shiki notation markers like
- * `// [!code highlight]` — intact. Erased type-only statements leave blank
- * lines and an erased trailing `as const`/`satisfies` leaves a space before
- * its semicolon; {@link tidy} cleans both up.
+ * formatting — and, crucially for {@link tidy}, the line structure — intact.
  */
 
 import { createRequire } from "node:module";
 
 import type { transform } from "sucrase";
 
+import { isLineRange, metaTokens } from "./fence-meta.ts";
 import { codeBlock, jsxAttribute, jsxFlowElement } from "./mdast.ts";
 import type { MdastNode, MdastVisitorContext } from "./mdast.ts";
 
@@ -27,16 +27,6 @@ interface CodeNode extends MdastNode {
   meta?: string | null;
   value: string;
 }
-
-/**
- * One fence-meta token: a quoted `key="..."` attribute (spaces allowed inside
- * the quotes) or a bare word, so a keyword inside a quoted value
- * (`title="enable ts2js later"`) never reads as a trigger.
- */
-const META_TOKEN = /[\w-]+=(?:"[^"]*"|'[^']*')|\S+/gu;
-
-const metaTokens = (meta: string | null | undefined): string[] =>
-  meta?.match(META_TOKEN) ?? [];
 
 /** Re-join filtered meta tokens, or `null` when nothing survives. */
 const joinMeta = (tokens: string[]): string | null =>
@@ -48,44 +38,116 @@ interface Sucrase {
   transform: typeof transform;
 }
 
-// Resolved lazily on the first triggered fence, so importing this module (at
-// Astro config load) never pays Sucrase's parse cost for ts2js-free sites.
-let sucrase: Sucrase | undefined;
+/** How the plugin obtains Sucrase; injectable so tests can fail the load. */
+export type SucraseLoader = () => Sucrase;
+
+// SAFETY: this resolves Blume's own `sucrase` dependency, whose CJS entry
+// exports the `transform` function the interface describes.
+const defaultLoader: SucraseLoader = () => require("sucrase") as Sucrase;
+
+/** Triggering fence languages, mapped to their generated tab's language. */
+const JS_LANG = new Map([
+  ["ts", "js"],
+  ["tsx", "jsx"],
+  ["typescript", "js"],
+]);
 
 /**
- * Clean up Sucrase's erasure artifacts: statements it removes wholesale
- * (interfaces, type aliases) leave runs of blank lines, and a removed
- * trailing type operator leaves a space before the semicolon. Line-anchored
- * regexes could in principle touch a multi-line template literal's interior,
- * but the worst case is cosmetic whitespace in a displayed snippet.
+ * Shiki's twoslash transformer triggers on this pattern over the *raw* fence
+ * meta (`RE_TWOSLASH` under `explicitTrigger`), so the keyword matches even
+ * inside a quoted attribute (`title="the twoslash guide"`). Mirror it
+ * exactly: any fence Shiki will twoslash-render is left alone, because hover
+ * data can't carry over to the generated JavaScript.
  */
-const tidy = (code: string): string =>
-  code
-    .replaceAll(/[ \t]+;$/gmu, ";")
-    .replaceAll(/[ \t]+$/gmu, "")
-    .replaceAll(/\n{3,}/gu, "\n\n")
-    .trim();
+const TWOSLASH = /\btwoslash\b/u;
 
-const stripTypes = (code: string, lang: string): string | undefined => {
-  // SAFETY: this resolves Blume's own `sucrase` dependency, whose CJS entry
-  // exports the `transform` function the interface describes.
-  sucrase ??= require("sucrase") as Sucrase;
-  try {
-    return tidy(
-      sucrase.transform(code, {
-        // Keep modern syntax (no downleveling) and the authored JSX.
-        disableESTransforms: true,
-        jsxRuntime: "preserve",
-        // The `jsx` transform only for `tsx`: with it enabled, a `ts` angle-
-        // bracket assertion (`<number>value`) would parse as JSX and fail.
-        transforms: lang === "tsx" ? ["typescript", "jsx"] : ["typescript"],
-      }).code
-    );
-  } catch {
-    // Sucrase throws on code it can't parse (pseudocode, deliberate
-    // fragments). Render the fence as authored instead of failing the build.
-    return undefined;
+/** A line holding nothing but a Shiki notation comment (`// [!code …]`). */
+const NOTATION_COMMENT = /^\s*\/\/\s*\[!code[^\]]*\]\s*$/u;
+
+/** A line holding nothing but a `//` comment. */
+const COMMENT_ONLY = /^\s*\/\//u;
+
+const isBlank = (text: string): boolean => text.trim().length === 0;
+
+interface TidyLine {
+  /** The line is blank because erasure removed its code. */
+  erased: boolean;
+  text: string;
+}
+
+/**
+ * Clean up Sucrase's erasure artifacts by comparing output to source line by
+ * line — erasure never adds or removes lines, so the two align (CRLF input
+ * included; the source's line endings are preserved). Untouched lines pass
+ * through verbatim, which keeps multi-line template literal interiors —
+ * whose blank runs and trailing spaces are string *content* — byte-exact.
+ * Lines erasure changed are cleaned:
+ *
+ * - the stray space a removed trailing type operator leaves before `;` (and
+ *   any trailing whitespace) is dropped;
+ * - a comment stranded by its erased code — including a trailing Shiki
+ *   notation marker (`// [!code highlight]`), which would otherwise
+ *   re-anchor to the next line — is removed along with the code it
+ *   annotated, as is an own-line notation marker whose target line was
+ *   erased;
+ * - blank runs erasure created collapse: a run that is entirely erasure
+ *   closes up, a run mixing erased and authored blanks keeps a single blank
+ *   line, and either is dropped at the snippet's edges.
+ */
+const tidy = (js: string, source: string): string => {
+  const eol = source.includes("\r\n") ? "\r\n" : "\n";
+  const srcLines = source.split(/\r?\n/u);
+  const srcLine = (index: number): string => srcLines[index] ?? "";
+  const lines = js.split(/\r?\n/u).map((line, index): TidyLine => {
+    const src = srcLine(index);
+    if (line === src) {
+      return { erased: false, text: line };
+    }
+    if (COMMENT_ONLY.test(line) && !COMMENT_ONLY.test(src)) {
+      return { erased: true, text: "" };
+    }
+    const text = line.replace(/[ \t]+;$/u, ";").replace(/[ \t]+$/u, "");
+    return { erased: text.length === 0, text };
+  });
+  // An own-line notation marker anchors to the line below it; if erasure
+  // blanked that target, the marker would highlight whatever ends up there
+  // instead, so it goes too.
+  for (const [index, line] of lines.entries()) {
+    const next = lines[index + 1];
+    if (
+      next &&
+      NOTATION_COMMENT.test(line.text) &&
+      isBlank(next.text) &&
+      !isBlank(srcLine(index + 1))
+    ) {
+      line.erased = true;
+      line.text = "";
+    }
   }
+  const out: string[] = [];
+  let blankRun: TidyLine[] = [];
+  let sawCode = false;
+  const flushBlanks = (atEnd: boolean) => {
+    if (blankRun.some((line) => line.erased)) {
+      if (sawCode && !atEnd && blankRun.some((line) => !line.erased)) {
+        out.push("");
+      }
+    } else {
+      out.push(...blankRun.map((line) => line.text));
+    }
+    blankRun = [];
+  };
+  for (const line of lines) {
+    if (isBlank(line.text)) {
+      blankRun.push(line);
+    } else {
+      flushBlanks(false);
+      out.push(line.text);
+      sawCode = true;
+    }
+  }
+  flushBlanks(true);
+  return out.join(eol);
 };
 
 /** Build the `<Tab>` holding one dialect's code fence. */
@@ -106,40 +168,97 @@ const tabNode = (
  * ranges from its meta (line numbers shift once types are gone) but keeps the
  * rest (`title="..."`, `lineNumbers`); the TypeScript tab keeps everything.
  * The keyword itself is stripped from both, which also guarantees the emitted
- * fences can never re-trigger the plugin. Fences that also carry `twoslash`
- * are left alone — hover data can't carry over to the generated JavaScript.
+ * fences can never re-trigger the plugin.
+ *
+ * The `loadSucrase` parameter exists for tests; production callers use the
+ * default, which resolves Blume's own dependency.
  */
-export const ts2jsPlugin = () => ({
-  code(node: CodeNode, ctx: MdastVisitorContext) {
-    if (node.lang !== "ts" && node.lang !== "tsx") {
-      return;
+export const ts2jsPlugin = (loadSucrase: SucraseLoader = defaultLoader) => {
+  // Resolved lazily on the first triggered fence, so importing this module
+  // (at Astro config load) never pays Sucrase's parse cost for ts2js-free
+  // sites. `null` records a failed load: every fence degrades to its
+  // authored form instead of failing the build, and the load is never
+  // retried.
+  let sucrase: Sucrase | null | undefined;
+
+  const stripTypes = (code: string, lang: string): string | undefined => {
+    if (sucrase === undefined) {
+      try {
+        sucrase = loadSucrase();
+      } catch {
+        sucrase = null;
+      }
     }
-    const tokens = metaTokens(node.meta);
-    if (!tokens.includes("ts2js") || tokens.includes("twoslash")) {
-      return;
+    if (sucrase === null) {
+      return undefined;
     }
-    const jsLang = node.lang === "tsx" ? "jsx" : "js";
-    const js = stripTypes(node.value, node.lang);
-    // Empty output means a types-only snippet; a blank JavaScript tab helps
-    // nobody, so keep the TypeScript fence as-is.
-    if (!js) {
-      return;
+    try {
+      return tidy(
+        sucrase.transform(code, {
+          // Keep modern syntax (no downleveling) and the authored JSX.
+          disableESTransforms: true,
+          jsxRuntime: "preserve",
+          // An import kept only for the reader's context must survive:
+          // without this, Sucrase drops any import with no value-position
+          // reference, and the JavaScript tab would show code whose bindings
+          // are undefined when copied. Type-only imports (`import type`,
+          // `{ type T }`) are still elided.
+          keepUnusedImports: true,
+          // The `jsx` transform only for `tsx`: with it enabled, a `ts`
+          // angle-bracket assertion (`<number>value`) would parse as JSX and
+          // fail.
+          transforms: lang === "tsx" ? ["typescript", "jsx"] : ["typescript"],
+        }).code,
+        code
+      );
+    } catch {
+      // Sucrase throws on code it can't parse (pseudocode, deliberate
+      // fragments). Render the fence as authored instead of failing the
+      // build.
+      return undefined;
     }
-    const kept = tokens.filter((token) => token !== "ts2js");
-    const jsMeta = kept.filter((token) => !token.startsWith("{"));
-    ctx.replaceNode(
-      node,
-      jsxFlowElement(
-        "Tabs",
-        // hash off: picking a dialect must not rewrite the page hash
-        // (clobbering the heading anchor the reader arrived with).
-        [jsxAttribute("hash", "false")],
-        [
-          tabNode("TypeScript", node.lang, node.value, joinMeta(kept)),
-          tabNode("JavaScript", jsLang, js, joinMeta(jsMeta)),
-        ]
-      )
-    );
-  },
-  name: "blume-ts2js",
-});
+  };
+
+  return {
+    code(node: CodeNode, ctx: MdastVisitorContext) {
+      const lang = node.lang ?? "";
+      const jsLang = JS_LANG.get(lang);
+      if (!jsLang) {
+        return;
+      }
+      const tokens = metaTokens(node.meta);
+      if (!tokens.includes("ts2js") || TWOSLASH.test(node.meta ?? "")) {
+        return;
+      }
+      const js = stripTypes(node.value, lang);
+      // Empty output means a types-only snippet; a blank JavaScript tab helps
+      // nobody, so keep the TypeScript fence as-is.
+      if (!js) {
+        return;
+      }
+      const kept = tokens.filter((token) => token !== "ts2js");
+      const jsMeta = kept.filter((token) => !isLineRange(token));
+      ctx.replaceNode(
+        node,
+        jsxFlowElement(
+          "Tabs",
+          [
+            // hash off: picking a dialect must not rewrite the page hash
+            // (clobbering the heading anchor the reader arrived with).
+            jsxAttribute("hash", "false"),
+            // Scope syncing to generated pairs: without a key, picking
+            // "JavaScript" here would also yank any authored group that has a
+            // same-titled tab (an SDK-language switcher, say) — one-way,
+            // since "TypeScript" wouldn't match to flip it back.
+            jsxAttribute("syncKey", "ts2js"),
+          ],
+          [
+            tabNode("TypeScript", lang, node.value, joinMeta(kept)),
+            tabNode("JavaScript", jsLang, js, joinMeta(jsMeta)),
+          ]
+        )
+      );
+    },
+    name: "blume-ts2js",
+  };
+};

--- a/packages/blume/src/markdown/ts2js.ts
+++ b/packages/blume/src/markdown/ts2js.ts
@@ -1,0 +1,145 @@
+/**
+ * Satteri MDAST plugin that turns a TypeScript fence carrying the `ts2js`
+ * meta keyword (```ts ts2js) into a `<Tabs>` group with the original
+ * TypeScript and an auto-generated JavaScript variant, so authors maintain
+ * one snippet and readers pick their dialect. Tab sync is on by default, so
+ * every TypeScript/JavaScript group on a page switches together.
+ *
+ * Types are stripped with Sucrase rather than the TypeScript compiler:
+ * `ts.transpileModule` re-prints the file (collapsed blank lines, four-space
+ * indentation, a `"use strict"` prologue on import-less snippets), while
+ * Sucrase erases type syntax token-by-token and leaves the author's
+ * formatting — including comments, and with them Shiki notation markers like
+ * `// [!code highlight]` — intact. Erased type-only statements leave blank
+ * lines and an erased trailing `as const`/`satisfies` leaves a space before
+ * its semicolon; {@link tidy} cleans both up.
+ */
+
+import { createRequire } from "node:module";
+
+import type { transform } from "sucrase";
+
+import { codeBlock, jsxAttribute, jsxFlowElement } from "./mdast.ts";
+import type { MdastNode, MdastVisitorContext } from "./mdast.ts";
+
+interface CodeNode extends MdastNode {
+  lang?: string | null;
+  meta?: string | null;
+  value: string;
+}
+
+/**
+ * One fence-meta token: a quoted `key="..."` attribute (spaces allowed inside
+ * the quotes) or a bare word, so a keyword inside a quoted value
+ * (`title="enable ts2js later"`) never reads as a trigger.
+ */
+const META_TOKEN = /[\w-]+=(?:"[^"]*"|'[^']*')|\S+/gu;
+
+const metaTokens = (meta: string | null | undefined): string[] =>
+  meta?.match(META_TOKEN) ?? [];
+
+/** Re-join filtered meta tokens, or `null` when nothing survives. */
+const joinMeta = (tokens: string[]): string | null =>
+  tokens.length > 0 ? tokens.join(" ") : null;
+
+const require = createRequire(import.meta.url);
+
+interface Sucrase {
+  transform: typeof transform;
+}
+
+// Resolved lazily on the first triggered fence, so importing this module (at
+// Astro config load) never pays Sucrase's parse cost for ts2js-free sites.
+let sucrase: Sucrase | undefined;
+
+/**
+ * Clean up Sucrase's erasure artifacts: statements it removes wholesale
+ * (interfaces, type aliases) leave runs of blank lines, and a removed
+ * trailing type operator leaves a space before the semicolon. Line-anchored
+ * regexes could in principle touch a multi-line template literal's interior,
+ * but the worst case is cosmetic whitespace in a displayed snippet.
+ */
+const tidy = (code: string): string =>
+  code
+    .replaceAll(/[ \t]+;$/gmu, ";")
+    .replaceAll(/[ \t]+$/gmu, "")
+    .replaceAll(/\n{3,}/gu, "\n\n")
+    .trim();
+
+const stripTypes = (code: string, lang: string): string | undefined => {
+  // SAFETY: this resolves Blume's own `sucrase` dependency, whose CJS entry
+  // exports the `transform` function the interface describes.
+  sucrase ??= require("sucrase") as Sucrase;
+  try {
+    return tidy(
+      sucrase.transform(code, {
+        // Keep modern syntax (no downleveling) and the authored JSX.
+        disableESTransforms: true,
+        jsxRuntime: "preserve",
+        // The `jsx` transform only for `tsx`: with it enabled, a `ts` angle-
+        // bracket assertion (`<number>value`) would parse as JSX and fail.
+        transforms: lang === "tsx" ? ["typescript", "jsx"] : ["typescript"],
+      }).code
+    );
+  } catch {
+    // Sucrase throws on code it can't parse (pseudocode, deliberate
+    // fragments). Render the fence as authored instead of failing the build.
+    return undefined;
+  }
+};
+
+/** Build the `<Tab>` holding one dialect's code fence. */
+const tabNode = (
+  title: string,
+  lang: string,
+  value: string,
+  meta: string | null
+) =>
+  jsxFlowElement(
+    "Tab",
+    [jsxAttribute("title", title)],
+    [codeBlock(lang, value, meta)]
+  );
+
+/**
+ * The `ts2js` fence plugin. The generated JavaScript tab drops `{1,3-5}` line
+ * ranges from its meta (line numbers shift once types are gone) but keeps the
+ * rest (`title="..."`, `lineNumbers`); the TypeScript tab keeps everything.
+ * The keyword itself is stripped from both, which also guarantees the emitted
+ * fences can never re-trigger the plugin. Fences that also carry `twoslash`
+ * are left alone — hover data can't carry over to the generated JavaScript.
+ */
+export const ts2jsPlugin = () => ({
+  code(node: CodeNode, ctx: MdastVisitorContext) {
+    if (node.lang !== "ts" && node.lang !== "tsx") {
+      return;
+    }
+    const tokens = metaTokens(node.meta);
+    if (!tokens.includes("ts2js") || tokens.includes("twoslash")) {
+      return;
+    }
+    const jsLang = node.lang === "tsx" ? "jsx" : "js";
+    const js = stripTypes(node.value, node.lang);
+    // Empty output means a types-only snippet; a blank JavaScript tab helps
+    // nobody, so keep the TypeScript fence as-is.
+    if (!js) {
+      return;
+    }
+    const kept = tokens.filter((token) => token !== "ts2js");
+    const jsMeta = kept.filter((token) => !token.startsWith("{"));
+    ctx.replaceNode(
+      node,
+      jsxFlowElement(
+        "Tabs",
+        // hash off: picking a dialect must not rewrite the page hash
+        // (clobbering the heading anchor the reader arrived with).
+        [jsxAttribute("hash", "false")],
+        [
+          tabNode("TypeScript", node.lang, node.value, joinMeta(kept)),
+          tabNode("JavaScript", jsLang, js, joinMeta(jsMeta)),
+        ]
+      )
+    );
+  },
+  name: "blume-ts2js",
+});

--- a/packages/blume/test/markdown.test.ts
+++ b/packages/blume/test/markdown.test.ts
@@ -541,8 +541,9 @@ const tabs = (
 ) =>
   jsxFlowElement(
     "Tabs",
-    // hash off so picking a dialect can't clobber the page hash.
-    [jsxAttribute("hash", "false")],
+    // hash off so picking a dialect can't clobber the page hash; a dedicated
+    // sync key so pairs sync with each other but not with authored groups.
+    [jsxAttribute("hash", "false"), jsxAttribute("syncKey", "ts2js")],
     [
       jsxFlowElement(
         "Tab",
@@ -662,10 +663,213 @@ describe("ts2jsPlugin", () => {
     ).toBeUndefined();
   });
 
-  it("leaves twoslash fences alone", () => {
+  it("leaves twoslash fences alone, matching Shiki's raw-meta trigger", () => {
     expect(
       ts2js({ lang: "ts", meta: "ts2js twoslash", value: "const x = 1;" })
     ).toBeUndefined();
+    // Shiki's explicit twoslash trigger matches inside quoted attrs too, so a
+    // fence it will twoslash-render must never be split into tabs.
+    expect(
+      ts2js({
+        lang: "ts",
+        meta: 'ts2js title="the twoslash guide"',
+        value: "const x = 1;",
+      })
+    ).toBeUndefined();
+  });
+
+  it("accepts the long-form typescript language", () => {
+    const result = ts2js({
+      lang: "typescript",
+      meta: "ts2js",
+      value: "const n: number = 1;",
+    });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "typescript", meta: null, value: "const n: number = 1;" },
+        { lang: "js", meta: null, value: "const n = 1;" }
+      )
+    );
+  });
+
+  it("keeps an import the snippet never references in a value position", () => {
+    const value = [
+      'import { defineConfig } from "blume";',
+      "",
+      "const port: number = 3000;",
+    ].join("\n");
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        {
+          lang: "js",
+          meta: null,
+          value: [
+            'import { defineConfig } from "blume";',
+            "",
+            "const port = 3000;",
+          ].join("\n"),
+        }
+      )
+    );
+  });
+
+  it("closes the gap an erased type-only import leaves", () => {
+    const value = [
+      'import { a } from "x";',
+      'import type { T } from "y";',
+      'import { b } from "z";',
+    ].join("\n");
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        {
+          lang: "js",
+          meta: null,
+          value: ['import { a } from "x";', 'import { b } from "z";'].join(
+            "\n"
+          ),
+        }
+      )
+    );
+  });
+
+  it("drops a notation marker stranded by its erased line", () => {
+    const value = [
+      "const a = 1;",
+      "type A = string; // [!code highlight]",
+      "const b = 2;",
+    ].join("\n");
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        { lang: "js", meta: null, value: "const a = 1;\nconst b = 2;" }
+      )
+    );
+  });
+
+  it("drops an own-line notation marker whose target was erased", () => {
+    const value = [
+      "const a = 1;",
+      "// [!code highlight]",
+      "interface X {",
+      "  a: string;",
+      "}",
+      "const b = 2;",
+    ].join("\n");
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        { lang: "js", meta: null, value: "const a = 1;\nconst b = 2;" }
+      )
+    );
+  });
+
+  it("keeps notation markers whose lines survive", () => {
+    const value = "const a: number = 1; // [!code highlight]\nconst b = 2;";
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        {
+          lang: "js",
+          meta: null,
+          value: "const a = 1; // [!code highlight]\nconst b = 2;",
+        }
+      )
+    );
+  });
+
+  it("drops a comment stranded by its erased code", () => {
+    const value = "type A = string; // the shape\nconst b = 2;";
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        { lang: "js", meta: null, value: "const b = 2;" }
+      )
+    );
+  });
+
+  it("leaves template literal interiors byte-exact", () => {
+    const value = [
+      "interface Q {",
+      "  x: string;",
+      "}",
+      "const sql = `SELECT *",
+      "",
+      "",
+      "",
+      "FROM users  ",
+      "WHERE x = 1  ;",
+      "`;",
+    ].join("\n");
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        {
+          lang: "js",
+          meta: null,
+          // The erased interface at the top is trimmed away; the template's
+          // blank runs and trailing spaces are string content and survive.
+          value: [
+            "const sql = `SELECT *",
+            "",
+            "",
+            "",
+            "FROM users  ",
+            "WHERE x = 1  ;",
+            "`;",
+          ].join("\n"),
+        }
+      )
+    );
+  });
+
+  it("preserves CRLF line endings while collapsing erased runs", () => {
+    const value = [
+      "const a = 1;",
+      "",
+      "interface X {",
+      "  a: string;",
+      "}",
+      "",
+      "const b = 2;",
+    ].join("\r\n");
+    const result = ts2js({ lang: "ts", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value },
+        {
+          lang: "js",
+          meta: null,
+          value: ["const a = 1;", "", "const b = 2;"].join("\r\n"),
+        }
+      )
+    );
+  });
+
+  it("degrades to the authored fence when Sucrase fails to load, once", () => {
+    let calls = 0;
+    const plugin = ts2jsPlugin(() => {
+      calls += 1;
+      throw new Error("missing sucrase");
+    });
+    const node = {
+      lang: "ts",
+      meta: "ts2js",
+      type: "code",
+      value: "const n: number = 1;",
+    };
+    expect(captureReplacement((ctx) => plugin.code(node, ctx))).toBeUndefined();
+    expect(captureReplacement((ctx) => plugin.code(node, ctx))).toBeUndefined();
+    // The failed load is cached: later fences don't re-pay the require.
+    expect(calls).toBe(1);
   });
 
   it("keeps a types-only fence as-is instead of emitting an empty tab", () => {

--- a/packages/blume/test/markdown.test.ts
+++ b/packages/blume/test/markdown.test.ts
@@ -35,6 +35,7 @@ import {
   toPackageCommands,
 } from "../src/markdown/package-commands.ts";
 import { packageInstallPlugin } from "../src/markdown/package-install.ts";
+import { ts2jsPlugin } from "../src/markdown/ts2js.ts";
 
 /** Run a plugin visitor and capture the node it replaces, if any. */
 const captureReplacement = (
@@ -232,6 +233,10 @@ describe(codeTitleTransformer, () => {
 
   it("does not treat the twoslash keyword as a title", () => {
     expect(metaAttrs("twoslash").dataTitle).toBeUndefined();
+  });
+
+  it("does not treat the ts2js keyword as a title", () => {
+    expect(metaAttrs("ts2js").dataTitle).toBeUndefined();
   });
 
   it("ignores line ranges and leaves plain blocks bare", () => {
@@ -516,6 +521,163 @@ describe("packageInstallPlugin", () => {
       packageInstallPlugin().code(node, ctx)
     );
     expect(result).toBeUndefined();
+  });
+});
+
+/** Run the ts2js plugin over a fence and capture the replacement, if any. */
+const ts2js = (node: {
+  lang?: string | null;
+  meta?: string | null;
+  value: string;
+}) =>
+  captureReplacement((ctx) =>
+    ts2jsPlugin().code({ type: "code", ...node }, ctx)
+  );
+
+/** The expected TypeScript/JavaScript tab pair. */
+const tabs = (
+  ts: { lang: string; meta: string | null; value: string },
+  js: { lang: string; meta: string | null; value: string }
+) =>
+  jsxFlowElement(
+    "Tabs",
+    // hash off so picking a dialect can't clobber the page hash.
+    [jsxAttribute("hash", "false")],
+    [
+      jsxFlowElement(
+        "Tab",
+        [jsxAttribute("title", "TypeScript")],
+        [codeBlock(ts.lang, ts.value, ts.meta)]
+      ),
+      jsxFlowElement(
+        "Tab",
+        [jsxAttribute("title", "JavaScript")],
+        [codeBlock(js.lang, js.value, js.meta)]
+      ),
+    ]
+  );
+
+describe("ts2jsPlugin", () => {
+  it("expands a marked ts fence into TypeScript/JavaScript tabs", () => {
+    const result = ts2js({
+      lang: "ts",
+      meta: "ts2js",
+      value: 'const greeting: string = "hi";',
+    });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value: 'const greeting: string = "hi";' },
+        { lang: "js", meta: null, value: 'const greeting = "hi";' }
+      )
+    );
+  });
+
+  it("preserves formatting, JSX, and comments; elides type-only imports", () => {
+    const value = [
+      'import { type ReactNode, useState } from "react";',
+      "",
+      "interface Props {",
+      "  children: ReactNode;",
+      "}",
+      "",
+      "// toggles [!code highlight]",
+      "export function Wrap({ children }: Props) {",
+      "  const [open, setOpen] = useState<boolean>(false);",
+      "",
+      "  return <div data-open={open}>{children}</div>;",
+      "}",
+    ].join("\n");
+    const result = ts2js({ lang: "tsx", meta: "ts2js", value });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "tsx", meta: null, value },
+        {
+          lang: "jsx",
+          meta: null,
+          value: [
+            'import { useState } from "react";',
+            "",
+            "// toggles [!code highlight]",
+            "export function Wrap({ children }) {",
+            "  const [open, setOpen] = useState(false);",
+            "",
+            "  return <div data-open={open}>{children}</div>;",
+            "}",
+          ].join("\n"),
+        }
+      )
+    );
+  });
+
+  it("cleans up the space an erased trailing type operator leaves", () => {
+    const result = ts2js({
+      lang: "ts",
+      meta: "ts2js",
+      value: "const pair = [1, 2] as const;",
+    });
+    expect(result).toStrictEqual(
+      tabs(
+        { lang: "ts", meta: null, value: "const pair = [1, 2] as const;" },
+        { lang: "js", meta: null, value: "const pair = [1, 2];" }
+      )
+    );
+  });
+
+  it("keeps titles on both tabs but drops line ranges from the JavaScript tab", () => {
+    const result = ts2js({
+      lang: "ts",
+      meta: 'ts2js title="demo.ts" {1-2} lineNumbers',
+      value: "const n: number = 1;",
+    });
+    expect(result).toStrictEqual(
+      tabs(
+        {
+          lang: "ts",
+          meta: 'title="demo.ts" {1-2} lineNumbers',
+          value: "const n: number = 1;",
+        },
+        {
+          lang: "js",
+          meta: 'title="demo.ts" lineNumbers',
+          value: "const n = 1;",
+        }
+      )
+    );
+  });
+
+  it("ignores fences in other languages", () => {
+    expect(ts2js({ lang: "js", meta: "ts2js", value: "1;" })).toBeUndefined();
+  });
+
+  it("ignores unmarked fences and keywords inside quoted attributes", () => {
+    expect(
+      ts2js({ lang: "ts", value: "const x: number = 1;" })
+    ).toBeUndefined();
+    expect(
+      ts2js({
+        lang: "ts",
+        meta: 'title="enable ts2js later"',
+        value: "const x: number = 1;",
+      })
+    ).toBeUndefined();
+  });
+
+  it("leaves twoslash fences alone", () => {
+    expect(
+      ts2js({ lang: "ts", meta: "ts2js twoslash", value: "const x = 1;" })
+    ).toBeUndefined();
+  });
+
+  it("keeps a types-only fence as-is instead of emitting an empty tab", () => {
+    expect(
+      ts2js({ lang: "ts", meta: "ts2js", value: "type Id = string;" })
+    ).toBeUndefined();
+  });
+
+  it("keeps a fence Sucrase can't parse as-is", () => {
+    expect(
+      ts2js({ lang: "ts", meta: "ts2js", value: "const = <<<" })
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

Mark a `ts` or `tsx` code fence with the `ts2js` meta keyword and Blume renders it as a synced TypeScript/JavaScript tab pair, generating the JavaScript variant at build time. Closes a parity gap with fumadocs' `remark-ts2js` — and uses the same fence marker, so content migrated from fumadocs works as-is.

````md
```ts ts2js
import { defineConfig } from "blume";

interface Author {
  name: string;
}

const author: Author = { name: "Hayden" };

export default defineConfig({
  title: `${author.name}'s docs`,
});
```
````

## How

- New Sätteri mdast visitor (`markdown/ts2js.ts`) modeled on `package-install`: replaces the fence with a `<Tabs hash="false">` pair, so tab syncing, flush code-panel padding, copy buttons, and the llms.txt Tabs down-leveling all come from existing machinery. MDX-only, like the other component-emitting plugins.
- Types are stripped with **Sucrase** (`jsxRuntime: "preserve"`), not `ts.transpileModule`: probing showed the TS emitter collapses blank lines, re-indents to 4 spaces, and prepends `"use strict"` to import-less snippets, while Sucrase preserves formatting, comments (including `[!code highlight]` notation), and JSX verbatim, and still elides type-only imports. Pure-JS dependency, plugin-internal, so no root devDep mirror or `RENDER_EXTERNAL_DEPS` entry needed. A small `tidy()` pass cleans Sucrase's erasure artifacts (blank-line runs, a stray space before `;`).
- Fence meta composes: the marker is stripped from both emitted tabs (which also makes re-triggering impossible), `title="..."` carries to both, `{1,3-5}` line ranges stay on the TypeScript tab only (line numbers shift once types are gone), and `twoslash` fences are left untouched since hover data can't carry over. `ts2js` joins the reserved meta keywords in `code-title.ts` so it can't be promoted to a block title.
- Types-only snippets and code Sucrase can't parse keep their original fence instead of emitting an empty or broken tab.

## Verification

- Unit tests for the visitor (trigger detection incl. quoted-attr safety, meta forwarding, JSX/formatting/comment preservation, artifact cleanup, all skip paths); touched files at 100% line and function coverage.
- Verified through the production MDX path (`mdxToJs` + the Astro highlight bridge): the visitor receives fence meta, both tabs compile with the right languages, and a forwarded title lands as `data-title` on both highlighted `<pre>`s.
- Docs section added under Code blocks in `syntax.mdx` with a live example; changeset included (`blume: patch`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added `ts2js` code fences with synchronized TypeScript and automatically generated JavaScript tabs.
- Preserves JSX, comments, formatting, titles, and supported line ranges.
- Added scoped tab synchronization with `syncKey`, preventing nested tab groups from interfering with one another.

## Bug Fixes
- Prevented `ts2js` from being interpreted as a code block title.
- Unsupported, types-only, or unparsable snippets remain unchanged.

## Documentation
- Documented `ts2js` syntax, behavior, limitations, and scoped tab synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->