### PR TITLE
fix: dismiss page-action dropdowns on outside click and Escape

### DIFF
--- a/.changeset/page-actions-dismiss.md
+++ b/.changeset/page-actions-dismiss.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Close the page-action dropdowns (Export, Open in chat, Connect to MCP) when clicking outside them or pressing Escape, instead of leaving the panel open until its own trigger is clicked again.
+Close the site's dropdowns — the page actions (Export, Open in chat, Connect to MCP), the header language switcher and the nav selectors — when clicking outside them, pressing Escape, or moving keyboard focus out of the panel, instead of leaving the panel open until its own trigger is clicked again. Escape returns focus to the trigger when pressed from inside the menu, and an Escape aimed at the search dialog no longer closes a menu beneath it.

--- a/.changeset/page-actions-dismiss.md
+++ b/.changeset/page-actions-dismiss.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Close the page-action dropdowns (Export, Open in chat, Connect to MCP) when clicking outside them or pressing Escape, instead of leaving the panel open until its own trigger is clicked again.

--- a/apps/docs/e2e/site.e2e.ts
+++ b/apps/docs/e2e/site.e2e.ts
@@ -88,7 +88,11 @@ test.describe("page actions", () => {
     // restored it rather than just observing the click that opened the menu.
     await dropdown.locator("summary").click();
     await expect(open).toHaveCount(1);
-    await dropdown.locator("[data-blume-menu] :is(a, button)").first().focus();
+    const menuItem = dropdown
+      .locator("[data-blume-menu] :is(a, button)")
+      .first();
+    await menuItem.focus();
+    await expect(menuItem).toBeFocused();
     await page.keyboard.press("Escape");
     await expect(open).toHaveCount(0);
     await expect(dropdown.locator("summary")).toBeFocused();

--- a/apps/docs/e2e/site.e2e.ts
+++ b/apps/docs/e2e/site.e2e.ts
@@ -84,9 +84,13 @@ test.describe("page actions", () => {
     await page.locator("#blume-content h1").click();
     await expect(open).toHaveCount(0);
 
+    // Focus moves into the panel first, so the assertion below proves Escape
+    // restored it rather than just observing the click that opened the menu.
     await dropdown.locator("summary").click();
     await expect(open).toHaveCount(1);
+    await dropdown.locator("[data-blume-menu] :is(a, button)").first().focus();
     await page.keyboard.press("Escape");
     await expect(open).toHaveCount(0);
+    await expect(dropdown.locator("summary")).toBeFocused();
   });
 });

--- a/apps/docs/e2e/site.e2e.ts
+++ b/apps/docs/e2e/site.e2e.ts
@@ -70,8 +70,8 @@ test.describe("custom pages", () => {
   });
 });
 
-test.describe("page actions", () => {
-  test("dropdowns close on an outside click and on Escape", async ({
+test.describe("dropdowns", () => {
+  test("page actions close on an outside click and on Escape", async ({
     page,
   }) => {
     await page.goto("/docs/quickstart");
@@ -96,5 +96,39 @@ test.describe("page actions", () => {
     await page.keyboard.press("Escape");
     await expect(open).toHaveCount(0);
     await expect(dropdown.locator("summary")).toBeFocused();
+  });
+
+  test("page actions close when keyboard focus leaves the panel", async ({
+    page,
+  }) => {
+    await page.goto("/docs/quickstart");
+    const actions = page.locator("[data-blume-page-actions]");
+    const dropdown = actions.locator("details").first();
+    const open = actions.locator("details[open]");
+
+    await dropdown.locator("summary").focus();
+    await page.keyboard.press("Enter");
+    await expect(open).toHaveCount(1);
+    // From the last item, one more Tab leaves the panel out its far side.
+    const lastItem = dropdown
+      .locator("[data-blume-menu] :is(a, button)")
+      .last();
+    await lastItem.focus();
+    await expect(lastItem).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(open).toHaveCount(0);
+  });
+
+  test("the header language switcher closes on an outside click", async ({
+    page,
+  }) => {
+    await page.goto("/docs/quickstart");
+    const switcher = page
+      .locator("header details[data-blume-dropdown]")
+      .first();
+    await switcher.locator("summary").click();
+    await expect(switcher).toHaveAttribute("open");
+    await page.locator("#blume-content h1").click();
+    await expect(switcher).not.toHaveAttribute("open");
   });
 });

--- a/apps/docs/e2e/site.e2e.ts
+++ b/apps/docs/e2e/site.e2e.ts
@@ -69,3 +69,24 @@ test.describe("custom pages", () => {
     await expect(page.locator("header").first()).toBeVisible();
   });
 });
+
+test.describe("page actions", () => {
+  test("dropdowns close on an outside click and on Escape", async ({
+    page,
+  }) => {
+    await page.goto("/docs/quickstart");
+    const actions = page.locator("[data-blume-page-actions]");
+    const dropdown = actions.locator("details").first();
+    const open = actions.locator("details[open]");
+
+    await dropdown.locator("summary").click();
+    await expect(open).toHaveCount(1);
+    await page.locator("#blume-content h1").click();
+    await expect(open).toHaveCount(0);
+
+    await dropdown.locator("summary").click();
+    await expect(open).toHaveCount(1);
+    await page.keyboard.press("Escape");
+    await expect(open).toHaveCount(0);
+  });
+});

--- a/packages/blume/src/components/dropdown-dismiss.ts
+++ b/packages/blume/src/components/dropdown-dismiss.ts
@@ -23,9 +23,16 @@
 
 const OPEN_DROPDOWN = "details[data-blume-dropdown][open]";
 
-/** The dropdown currently open, if any. At most one is open at a time. */
-const openDropdown = (): HTMLDetailsElement | null =>
-  document.querySelector<HTMLDetailsElement>(OPEN_DROPDOWN);
+/**
+ * Every dropdown currently open. Each component group keeps itself to one
+ * open panel, but a page holds several groups (the header selectors and the
+ * page actions), and a browser that doesn't focus a `<summary>` on click lets
+ * a keyboard-opened panel join a pointer-opened one — so the dismissal rules
+ * apply to all of them, never just the first in DOM order.
+ */
+const openDropdowns = (): HTMLDetailsElement[] => [
+  ...document.querySelectorAll<HTMLDetailsElement>(OPEN_DROPDOWN),
+];
 
 /**
  * Close `open`. `restoreFocus` moves focus back to its trigger, which a
@@ -44,11 +51,11 @@ const isInside = (
 ): boolean => target instanceof Node && dropdown.contains(target);
 
 const onPointerDown = (event: PointerEvent): void => {
-  const open = openDropdown();
-  if (!open || isInside(open, event.target)) {
-    return;
+  for (const open of openDropdowns()) {
+    if (!isInside(open, event.target)) {
+      dismiss(open, false);
+    }
   }
-  dismiss(open, false);
 };
 
 const onKeyDown = (event: KeyboardEvent): void => {
@@ -63,36 +70,35 @@ const onKeyDown = (event: KeyboardEvent): void => {
   if (event.target instanceof Element && event.target.closest("dialog")) {
     return;
   }
-  const open = openDropdown();
-  if (!open) {
-    return;
-  }
-  // Only a keypress that originated inside the panel gets its focus returned
-  // to the trigger; yanking focus from an unrelated control the user had
+  // Only a keypress that originated inside a panel gets its focus returned
+  // to that trigger; yanking focus from an unrelated control the user had
   // moved on to would be a surprise.
-  dismiss(open, isInside(open, event.target));
+  for (const open of openDropdowns()) {
+    dismiss(open, isInside(open, event.target));
+  }
 };
 
 const onFocusOut = (event: FocusEvent): void => {
-  const open = openDropdown();
-  // A null `relatedTarget` means focus went nowhere focusable (a click on
-  // plain content, the panel being hidden, the window blurring) — the pointer
-  // and blur legs own those, and closing here would hide a panel item before
-  // its own click lands in browsers that don't focus buttons on press.
+  // Only focus *leaving a panel* counts: a move between two unrelated controls
+  // (a dialog handing focus back to its trigger, say) must not close a panel
+  // that never held focus. And a null `relatedTarget` means focus went
+  // nowhere focusable (a click on plain content, the panel being hidden, the
+  // window blurring) — the pointer and blur legs own those, and closing here
+  // would hide a panel item before its own click lands in browsers that
+  // don't focus buttons on press.
   const { relatedTarget } = event;
-  if (
-    !open ||
-    !(relatedTarget instanceof Node) ||
-    open.contains(relatedTarget)
-  ) {
+  if (!(relatedTarget instanceof Node)) {
     return;
   }
-  dismiss(open, false);
+  for (const open of openDropdowns()) {
+    if (isInside(open, event.target) && !open.contains(relatedTarget)) {
+      dismiss(open, false);
+    }
+  }
 };
 
 const onWindowBlur = (): void => {
-  const open = openDropdown();
-  if (open) {
+  for (const open of openDropdowns()) {
     dismiss(open, false);
   }
 };

--- a/packages/blume/src/components/dropdown-dismiss.ts
+++ b/packages/blume/src/components/dropdown-dismiss.ts
@@ -1,0 +1,116 @@
+/**
+ * Light-dismiss for the site's `<details>`-based dropdowns: the page actions
+ * (Export / Open in chat / Connect to MCP), the header language switcher and
+ * the nav selectors all render the same floating `<details>` + absolute panel,
+ * and a native `<details>` only closes when its own `<summary>` is clicked
+ * again, leaving the panel hanging over the page. Any dropdown that opts in
+ * with `data-blume-dropdown` gets the four legs of a real menu:
+ *
+ * - a pointer press outside the open panel closes it;
+ * - Escape closes it, restoring focus to the trigger when the keypress
+ *   originated inside the panel;
+ * - keyboard focus leaving the panel closes it;
+ * - the window losing focus closes it — the only signal the parent document
+ *   gets when a press lands inside an `<iframe>` embed, since pointer events
+ *   in a child browsing context never propagate up.
+ *
+ * Every listener sits on `document`/`window` once per real page load and
+ * queries the DOM live, so client-router swaps (which rebuild the dropdown
+ * markup) need no re-init and never stack duplicate listeners. Per-component
+ * behavior — one-open-at-a-time within a group, viewport flipping — stays in
+ * the component that owns it.
+ */
+
+const OPEN_DROPDOWN = "details[data-blume-dropdown][open]";
+
+/** The dropdown currently open, if any. At most one is open at a time. */
+const openDropdown = (): HTMLDetailsElement | null =>
+  document.querySelector<HTMLDetailsElement>(OPEN_DROPDOWN);
+
+/**
+ * Close `open`. `restoreFocus` moves focus back to its trigger, which a
+ * keyboard dismissal wants and a pointer or focus-driven one does not.
+ */
+const dismiss = (open: HTMLDetailsElement, restoreFocus: boolean): void => {
+  open.open = false;
+  if (restoreFocus) {
+    open.querySelector<HTMLElement>("summary")?.focus();
+  }
+};
+
+const isInside = (
+  dropdown: HTMLDetailsElement,
+  target: EventTarget | null
+): boolean => target instanceof Node && dropdown.contains(target);
+
+const onPointerDown = (event: PointerEvent): void => {
+  const open = openDropdown();
+  if (!open || isInside(open, event.target)) {
+    return;
+  }
+  dismiss(open, false);
+};
+
+const onKeyDown = (event: KeyboardEvent): void => {
+  // `isComposing`: an IME cancel arrives as Escape and isn't a dismissal.
+  if (event.key !== "Escape" || event.isComposing) {
+    return;
+  }
+  // An Escape aimed at a modal surface stacked on top (the search dialog
+  // traps focus inside itself) dismisses that surface only — the same guard
+  // the Ask panel applies. Everything outside the modal is inert, so a focus
+  // restore here could not land anyway.
+  if (event.target instanceof Element && event.target.closest("dialog")) {
+    return;
+  }
+  const open = openDropdown();
+  if (!open) {
+    return;
+  }
+  // Only a keypress that originated inside the panel gets its focus returned
+  // to the trigger; yanking focus from an unrelated control the user had
+  // moved on to would be a surprise.
+  dismiss(open, isInside(open, event.target));
+};
+
+const onFocusOut = (event: FocusEvent): void => {
+  const open = openDropdown();
+  // A null `relatedTarget` means focus went nowhere focusable (a click on
+  // plain content, the panel being hidden, the window blurring) — the pointer
+  // and blur legs own those, and closing here would hide a panel item before
+  // its own click lands in browsers that don't focus buttons on press.
+  const { relatedTarget } = event;
+  if (
+    !open ||
+    !(relatedTarget instanceof Node) ||
+    open.contains(relatedTarget)
+  ) {
+    return;
+  }
+  dismiss(open, false);
+};
+
+const onWindowBlur = (): void => {
+  const open = openDropdown();
+  if (open) {
+    dismiss(open, false);
+  }
+};
+
+let installed = false;
+
+/**
+ * Register the document/window listeners. Idempotent: every component that
+ * renders a dropdown calls this from its own script, and a page may render
+ * several of them.
+ */
+export const installDropdownDismiss = (): void => {
+  if (installed) {
+    return;
+  }
+  installed = true;
+  document.addEventListener("pointerdown", onPointerDown);
+  document.addEventListener("keydown", onKeyDown);
+  document.addEventListener("focusout", onFocusOut);
+  window.addEventListener("blur", onWindowBlur);
+};

--- a/packages/blume/src/components/layout/LanguageSwitcher.astro
+++ b/packages/blume/src/components/layout/LanguageSwitcher.astro
@@ -20,7 +20,7 @@ const menuRowClass =
 
 {
   options.length > 1 && (
-    <details class="group relative">
+    <details class="group relative" data-blume-dropdown>
       <summary
         aria-label={label}
         class={`${iconButton} list-none [&::-webkit-details-marker]:hidden`}
@@ -56,3 +56,11 @@ const menuRowClass =
     </details>
   )
 }
+
+<script>
+  import { installDropdownDismiss } from "../dropdown-dismiss.ts";
+
+  // Outside-click / Escape / focus-out dismissal, shared with the nav
+  // selectors and the page actions.
+  installDropdownDismiss();
+</script>

--- a/packages/blume/src/components/layout/NavSelector.astro
+++ b/packages/blume/src/components/layout/NavSelector.astro
@@ -2,8 +2,9 @@
 import { withBase } from "../islands/base-path.ts";
 // A top-level navigation selector: a dropdown that switches
 // between partitions of the site — a product, a version, or any grouped set of
-// destinations (`navigation.selectors` in the config). Zero-JS, built on
-// <details>/<summary> like the language switcher.
+// destinations (`navigation.selectors` in the config). Built on
+// <details>/<summary> like the language switcher; the only script is the
+// shared light-dismiss so an open panel doesn't linger over the page.
 import type { NavSelector } from "../../core/types.ts";
 import Icon from "../Icon.astro";
 import { isUnderPath } from "../../core/navigation.ts";
@@ -40,7 +41,7 @@ const menuRowClass =
 
 {
   selector.items.length > 0 && (
-    <details class="group relative">
+    <details class="group relative" data-blume-dropdown>
       <summary
         aria-label={selector.label}
         class={`${iconButton} list-none [&::-webkit-details-marker]:hidden`}
@@ -85,3 +86,11 @@ const menuRowClass =
     </details>
   )
 }
+
+<script>
+  import { installDropdownDismiss } from "../dropdown-dismiss.ts";
+
+  // Outside-click / Escape / focus-out dismissal, shared with the language
+  // switcher and the page actions.
+  installDropdownDismiss();
+</script>

--- a/packages/blume/src/components/layout/PageActions.astro
+++ b/packages/blume/src/components/layout/PageActions.astro
@@ -122,7 +122,7 @@ const menuRowClass =
 
   {
     (exportPdf || exportEpub) && (
-      <details class="group relative">
+      <details class="group relative" data-blume-dropdown>
         <summary
           class={`${rowClass} cursor-pointer list-none [&::-webkit-details-marker]:hidden`}
         >
@@ -159,7 +159,7 @@ const menuRowClass =
 
   {
     providers.length > 0 && (
-      <details class="group relative">
+      <details class="group relative" data-blume-dropdown>
         <summary
           class={`${rowClass} cursor-pointer list-none [&::-webkit-details-marker]:hidden`}
         >
@@ -199,7 +199,7 @@ const menuRowClass =
 
   {
     mcpUrl && (
-      <details class="group relative">
+      <details class="group relative" data-blume-dropdown>
         <summary
           class={`${rowClass} cursor-pointer list-none [&::-webkit-details-marker]:hidden`}
         >
@@ -252,6 +252,7 @@ const menuRowClass =
 
 <script>
   import { copyText, flashLabel } from "../copy-feedback.ts";
+  import { installDropdownDismiss } from "../dropdown-dismiss.ts";
   import { prefixBase } from "../islands/base-path.ts";
   import { rafThrottle } from "../raf-throttle.ts";
 
@@ -348,34 +349,9 @@ hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }`;
     })
   );
 
-  // A native <details> only closes when its own summary is clicked, so an open
-  // panel would linger over the page. Dismiss it like a real menu: any pointer
-  // press outside the open dropdown closes it. Registered at module scope for
-  // the same reason as the resize handler above.
-  document.addEventListener("pointerdown", (event) => {
-    const open = openDropdown();
-    if (!open) {
-      return;
-    }
-    const target = event.target;
-    if (target instanceof Node && open.contains(target)) {
-      return;
-    }
-    open.open = false;
-  });
-
-  // Escape closes the menu and returns focus to the trigger that opened it.
-  document.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape") {
-      return;
-    }
-    const open = openDropdown();
-    if (!open) {
-      return;
-    }
-    open.open = false;
-    open.querySelector<HTMLElement>("summary")?.focus();
-  });
+  // Outside-click / Escape / focus-out dismissal is the shared <details>
+  // dropdown behavior (also the header language switcher and nav selectors).
+  installDropdownDismiss();
 
   // Per-page setup, run on the initial load and again after every
   // client-router swap: the swap rebuilds the actions menu from

--- a/packages/blume/src/components/layout/PageActions.astro
+++ b/packages/blume/src/components/layout/PageActions.astro
@@ -329,6 +329,11 @@ hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }`;
     menu.classList.toggle("mb-1", flipUp);
   };
 
+  const openDropdown = () =>
+    document.querySelector<HTMLDetailsElement>(
+      "[data-blume-page-actions] details[open]"
+    );
+
   // rAF-coalesced so a live resize drag re-reads layout once per frame, not
   // once per event, while the open menu still tracks the viewport. Registered
   // once at module scope (this bundle runs once per real page load) and
@@ -336,14 +341,41 @@ hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }`;
   window.addEventListener(
     "resize",
     rafThrottle(() => {
-      const open = document.querySelector<HTMLDetailsElement>(
-        "[data-blume-page-actions] details[open]"
-      );
+      const open = openDropdown();
       if (open) {
         placeMenu(open);
       }
     })
   );
+
+  // A native <details> only closes when its own summary is clicked, so an open
+  // panel would linger over the page. Dismiss it like a real menu: any pointer
+  // press outside the open dropdown closes it. Registered at module scope for
+  // the same reason as the resize handler above.
+  document.addEventListener("pointerdown", (event) => {
+    const open = openDropdown();
+    if (!open) {
+      return;
+    }
+    const target = event.target;
+    if (target instanceof Node && open.contains(target)) {
+      return;
+    }
+    open.open = false;
+  });
+
+  // Escape closes the menu and returns focus to the trigger that opened it.
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") {
+      return;
+    }
+    const open = openDropdown();
+    if (!open) {
+      return;
+    }
+    open.open = false;
+    open.querySelector<HTMLElement>("summary")?.focus();
+  });
 
   // Per-page setup, run on the initial load and again after every
   // client-router swap: the swap rebuilds the actions menu from

--- a/packages/blume/test/dropdown-dismiss.test.ts
+++ b/packages/blume/test/dropdown-dismiss.test.ts
@@ -15,18 +15,20 @@ import {
  * restored afterwards so later test files see the environment they expect.
  */
 
-/** A minimal element: tag, tree, `<details>` open state, focus tracking. */
+/** A minimal element: tag, attributes, tree, `<details>` open state, focus. */
 class FakeEl {
+  attributes = new Set<string>();
   children: FakeEl[] = [];
   focused = false;
   open = false;
   parent: FakeEl | null = null;
   tag: string;
-  dropdown: boolean;
 
-  constructor(tag: string, dropdown = false) {
+  constructor(tag: string, ...attributes: string[]) {
     this.tag = tag;
-    this.dropdown = dropdown;
+    for (const name of attributes) {
+      this.attributes.add(name);
+    }
   }
 
   append(...nodes: FakeEl[]): this {
@@ -52,16 +54,33 @@ class FakeEl {
     return this.parent?.closest(tag) ?? null;
   }
 
-  /** Only the two selectors the module issues. */
-  querySelector(selector: string): FakeEl | null {
-    if (selector === "summary") {
-      return this.descendants().find((node) => node.tag === "summary") ?? null;
+  /**
+   * Tag plus ANDed presence clauses, the shape of the selectors the module
+   * issues. `[open]` reads the live `open` state so the fixture answers the
+   * real `details[data-blume-dropdown][open]` — and would answer a regressed
+   * `details[open]` with the plain collapsible that precedes the dropdowns.
+   */
+  matches(selector: string): boolean {
+    const [tag] = /^[a-z-]+/u.exec(selector) ?? [];
+    if (tag && this.tag !== tag) {
+      return false;
     }
-    return (
-      this.descendants().find(
-        (node) => node.tag === "details" && node.dropdown && node.open
-      ) ?? null
-    );
+    for (const clause of selector.matchAll(/\[(?<name>[^\]]+)\]/gu)) {
+      const name = clause.groups?.name ?? "";
+      const present = name === "open" ? this.open : this.attributes.has(name);
+      if (!present) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  querySelectorAll(selector: string): FakeEl[] {
+    return this.descendants().filter((node) => node.matches(selector));
+  }
+
+  querySelector(selector: string): FakeEl | null {
+    return this.querySelectorAll(selector)[0] ?? null;
   }
 
   focus(): void {
@@ -79,53 +98,61 @@ interface FakeEvent {
 
 type Listener = (event: FakeEvent) => void;
 
-const documentListeners = new Map<string, Listener>();
-const windowListeners = new Map<string, Listener>();
+/** Every registration kept, so a duplicate `addEventListener` is visible. */
+const documentListeners = new Map<string, Listener[]>();
+const windowListeners = new Map<string, Listener[]>();
 
-// The tree: body > [dialog > input, article > link, dropdown(details > summary, div > button)]
+const register =
+  (store: Map<string, Listener[]>) => (type: string, listener: Listener) => {
+    store.set(type, [...(store.get(type) ?? []), listener]);
+  };
+
+// The tree, in DOM order:
+//   body > dialog > input
+//        > article > collapsible(details[open]) > a
+//        > header(details[data-blume-dropdown]) > summary, div > a
+//        > actions(details[data-blume-dropdown]) > summary, div > button
 const body = new FakeEl("body");
 const dialog = new FakeEl("dialog");
 const searchInput = new FakeEl("input");
 dialog.append(searchInput);
 const article = new FakeEl("article");
-const link = new FakeEl("a");
-article.append(link);
-const dropdown = new FakeEl("details", true);
-const summary = new FakeEl("summary");
-const panel = new FakeEl("div");
-const item = new FakeEl("button");
-panel.append(item);
-dropdown.append(summary, panel);
-// A second, non-dropdown <details> (a collapsible in the article) must never
-// be treated as the open menu.
+// A plain open <details> (a collapsible in the article) precedes the dropdowns
+// so a lookup that dropped the `data-blume-dropdown` clause would find it.
 const collapsible = new FakeEl("details");
 collapsible.open = true;
-body.append(dialog, article, dropdown, collapsible);
+const link = new FakeEl("a");
+article.append(collapsible, link);
+const header = new FakeEl("details", "data-blume-dropdown");
+const headerSummary = new FakeEl("summary");
+const headerItem = new FakeEl("a");
+header.append(headerSummary, new FakeEl("div").append(headerItem));
+const actions = new FakeEl("details", "data-blume-dropdown");
+const actionsSummary = new FakeEl("summary");
+const actionsItem = new FakeEl("button");
+actions.append(actionsSummary, new FakeEl("div").append(actionsItem));
+body.append(dialog, article, header, actions);
 
 const fakeDocument = {
-  addEventListener: (type: string, listener: Listener) => {
-    documentListeners.set(type, listener);
-  },
-  querySelector: (selector: string) => body.querySelector(selector),
+  addEventListener: register(documentListeners),
+  querySelectorAll: (selector: string) => body.querySelectorAll(selector),
 };
-const fakeWindow = {
-  addEventListener: (type: string, listener: Listener) => {
-    windowListeners.set(type, listener);
-  },
-};
+const fakeWindow = { addEventListener: register(windowListeners) };
 
 const fire = (
   where: "document" | "window",
   type: string,
   event: FakeEvent = {}
 ): void => {
-  const listener = (
+  const listeners = (
     where === "document" ? documentListeners : windowListeners
   ).get(type);
-  if (!listener) {
+  if (!listeners?.length) {
     throw new Error(`no ${where} listener for ${type}`);
   }
-  listener(event);
+  for (const listener of listeners) {
+    listener(event);
+  }
 };
 
 const saved = new Map(
@@ -165,124 +192,152 @@ afterAll(() => {
   }
 });
 
+// Each case starts with the page-actions dropdown open and the header one
+// closed; the "several open" cases open the header one themselves.
 beforeEach(() => {
-  dropdown.open = true;
-  summary.focused = false;
+  actions.open = true;
+  header.open = false;
+  actionsSummary.focused = false;
+  headerSummary.focused = false;
 });
 
 describe("installDropdownDismiss", () => {
   it("registers each listener once, even when several components install", () => {
     installDropdownDismiss();
     installDropdownDismiss();
-    expect([...documentListeners.keys()].toSorted()).toEqual([
-      "focusout",
-      "keydown",
-      "pointerdown",
+    expect(
+      [...documentListeners].map(([type, list]) => [type, list.length])
+    ).toEqual([
+      ["pointerdown", 1],
+      ["keydown", 1],
+      ["focusout", 1],
     ]);
-    expect([...windowListeners.keys()]).toEqual(["blur"]);
+    expect(
+      [...windowListeners].map(([type, list]) => [type, list.length])
+    ).toEqual([["blur", 1]]);
   });
 });
 
 describe("pointerdown", () => {
   it("closes the open dropdown on a press outside it", () => {
     fire("document", "pointerdown", { target: link });
-    expect(dropdown.open).toBe(false);
-    expect(summary.focused).toBe(false);
+    expect(actions.open).toBe(false);
+    expect(actionsSummary.focused).toBe(false);
   });
 
   it("leaves the dropdown open on a press inside it", () => {
-    fire("document", "pointerdown", { target: item });
-    expect(dropdown.open).toBe(true);
-    fire("document", "pointerdown", { target: summary });
-    expect(dropdown.open).toBe(true);
+    fire("document", "pointerdown", { target: actionsItem });
+    expect(actions.open).toBe(true);
+    fire("document", "pointerdown", { target: actionsSummary });
+    expect(actions.open).toBe(true);
   });
 
   it("closes on a press whose target is not a node", () => {
     fire("document", "pointerdown", { target: null });
-    expect(dropdown.open).toBe(false);
+    expect(actions.open).toBe(false);
   });
 
-  it("does nothing when no dropdown is open", () => {
-    dropdown.open = false;
+  it("never touches a plain <details> collapsible", () => {
+    actions.open = false;
     fire("document", "pointerdown", { target: link });
-    expect(dropdown.open).toBe(false);
     expect(collapsible.open).toBe(true);
+  });
+
+  it("closes every open dropdown except the one pressed", () => {
+    header.open = true;
+    fire("document", "pointerdown", { target: headerItem });
+    expect(header.open).toBe(true);
+    expect(actions.open).toBe(false);
   });
 });
 
 describe("keydown", () => {
   it("ignores keys other than Escape", () => {
-    fire("document", "keydown", { key: "Enter", target: item });
-    expect(dropdown.open).toBe(true);
+    fire("document", "keydown", { key: "Enter", target: actionsItem });
+    expect(actions.open).toBe(true);
   });
 
   it("ignores an IME composition cancel", () => {
     fire("document", "keydown", {
       isComposing: true,
       key: "Escape",
-      target: item,
+      target: actionsItem,
     });
-    expect(dropdown.open).toBe(true);
+    expect(actions.open).toBe(true);
   });
 
   it("leaves a dropdown under a modal dialog alone", () => {
     fire("document", "keydown", { key: "Escape", target: searchInput });
-    expect(dropdown.open).toBe(true);
-    expect(summary.focused).toBe(false);
+    expect(actions.open).toBe(true);
+    expect(actionsSummary.focused).toBe(false);
   });
 
   it("closes and returns focus to the trigger when Escape came from inside", () => {
-    fire("document", "keydown", { key: "Escape", target: item });
-    expect(dropdown.open).toBe(false);
-    expect(summary.focused).toBe(true);
+    fire("document", "keydown", { key: "Escape", target: actionsItem });
+    expect(actions.open).toBe(false);
+    expect(actionsSummary.focused).toBe(true);
   });
 
   it("closes without moving focus when Escape came from elsewhere", () => {
     fire("document", "keydown", { key: "Escape", target: link });
-    expect(dropdown.open).toBe(false);
-    expect(summary.focused).toBe(false);
+    expect(actions.open).toBe(false);
+    expect(actionsSummary.focused).toBe(false);
   });
 
-  it("does nothing when no dropdown is open", () => {
-    dropdown.open = false;
-    fire("document", "keydown", { key: "Escape", target: link });
-    expect(summary.focused).toBe(false);
+  it("closes every open dropdown, restoring focus only to the one Escape came from", () => {
+    header.open = true;
+    fire("document", "keydown", { key: "Escape", target: headerItem });
+    expect(header.open).toBe(false);
+    expect(actions.open).toBe(false);
+    expect(headerSummary.focused).toBe(true);
+    expect(actionsSummary.focused).toBe(false);
   });
 });
 
 describe("focusout", () => {
-  it("closes when focus moves to an element outside the dropdown", () => {
-    fire("document", "focusout", { relatedTarget: link, target: item });
-    expect(dropdown.open).toBe(false);
-    expect(summary.focused).toBe(false);
+  it("closes when focus leaves the dropdown for an element outside it", () => {
+    fire("document", "focusout", { relatedTarget: link, target: actionsItem });
+    expect(actions.open).toBe(false);
+    expect(actionsSummary.focused).toBe(false);
   });
 
   it("stays open while focus moves within the dropdown", () => {
-    fire("document", "focusout", { relatedTarget: item, target: summary });
-    expect(dropdown.open).toBe(true);
+    fire("document", "focusout", {
+      relatedTarget: actionsItem,
+      target: actionsSummary,
+    });
+    expect(actions.open).toBe(true);
   });
 
   it("stays open when focus goes nowhere focusable", () => {
-    fire("document", "focusout", { relatedTarget: null, target: item });
-    expect(dropdown.open).toBe(true);
+    fire("document", "focusout", { relatedTarget: null, target: actionsItem });
+    expect(actions.open).toBe(true);
   });
 
-  it("does nothing when no dropdown is open", () => {
-    dropdown.open = false;
-    fire("document", "focusout", { relatedTarget: link, target: item });
-    expect(dropdown.open).toBe(false);
+  it("stays open when focus moves between elements outside it", () => {
+    fire("document", "focusout", { relatedTarget: link, target: searchInput });
+    expect(actions.open).toBe(true);
+  });
+
+  it("closes only the dropdown focus left", () => {
+    header.open = true;
+    fire("document", "focusout", { relatedTarget: link, target: headerItem });
+    expect(header.open).toBe(false);
+    expect(actions.open).toBe(true);
   });
 });
 
 describe("window blur", () => {
-  it("closes the open dropdown", () => {
+  it("closes every open dropdown", () => {
+    header.open = true;
     fire("window", "blur");
-    expect(dropdown.open).toBe(false);
-    expect(summary.focused).toBe(false);
+    expect(header.open).toBe(false);
+    expect(actions.open).toBe(false);
+    expect(actionsSummary.focused).toBe(false);
   });
 
-  it("does nothing when no dropdown is open", () => {
-    dropdown.open = false;
+  it("never touches a plain <details> collapsible", () => {
+    actions.open = false;
     fire("window", "blur");
     expect(collapsible.open).toBe(true);
   });

--- a/packages/blume/test/dropdown-dismiss.test.ts
+++ b/packages/blume/test/dropdown-dismiss.test.ts
@@ -1,0 +1,289 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+/**
+ * Tests for the shared `<details>` dropdown light-dismiss
+ * (`src/components/dropdown-dismiss.ts`). Browser globals are faked the way
+ * copy-feedback.test.ts fakes them — a hand-rolled tree with just the surface
+ * the module reads (`contains`, `closest("dialog")`, `open`, `focus`) — and
+ * restored afterwards so later test files see the environment they expect.
+ */
+
+/** A minimal element: tag, tree, `<details>` open state, focus tracking. */
+class FakeEl {
+  children: FakeEl[] = [];
+  focused = false;
+  open = false;
+  parent: FakeEl | null = null;
+  tag: string;
+  dropdown: boolean;
+
+  constructor(tag: string, dropdown = false) {
+    this.tag = tag;
+    this.dropdown = dropdown;
+  }
+
+  append(...nodes: FakeEl[]): this {
+    for (const node of nodes) {
+      node.parent = this;
+      this.children.push(node);
+    }
+    return this;
+  }
+
+  descendants(): FakeEl[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+
+  contains(node: FakeEl): boolean {
+    return node === this || this.descendants().includes(node);
+  }
+
+  closest(tag: string): FakeEl | null {
+    if (this.tag === tag) {
+      return this;
+    }
+    return this.parent?.closest(tag) ?? null;
+  }
+
+  /** Only the two selectors the module issues. */
+  querySelector(selector: string): FakeEl | null {
+    if (selector === "summary") {
+      return this.descendants().find((node) => node.tag === "summary") ?? null;
+    }
+    return (
+      this.descendants().find(
+        (node) => node.tag === "details" && node.dropdown && node.open
+      ) ?? null
+    );
+  }
+
+  focus(): void {
+    this.focused = true;
+  }
+}
+
+/** The subset of the pointer / keyboard / focus event surface the module reads. */
+interface FakeEvent {
+  isComposing?: boolean;
+  key?: string;
+  relatedTarget?: FakeEl | null;
+  target?: FakeEl | null;
+}
+
+type Listener = (event: FakeEvent) => void;
+
+const documentListeners = new Map<string, Listener>();
+const windowListeners = new Map<string, Listener>();
+
+// The tree: body > [dialog > input, article > link, dropdown(details > summary, div > button)]
+const body = new FakeEl("body");
+const dialog = new FakeEl("dialog");
+const searchInput = new FakeEl("input");
+dialog.append(searchInput);
+const article = new FakeEl("article");
+const link = new FakeEl("a");
+article.append(link);
+const dropdown = new FakeEl("details", true);
+const summary = new FakeEl("summary");
+const panel = new FakeEl("div");
+const item = new FakeEl("button");
+panel.append(item);
+dropdown.append(summary, panel);
+// A second, non-dropdown <details> (a collapsible in the article) must never
+// be treated as the open menu.
+const collapsible = new FakeEl("details");
+collapsible.open = true;
+body.append(dialog, article, dropdown, collapsible);
+
+const fakeDocument = {
+  addEventListener: (type: string, listener: Listener) => {
+    documentListeners.set(type, listener);
+  },
+  querySelector: (selector: string) => body.querySelector(selector),
+};
+const fakeWindow = {
+  addEventListener: (type: string, listener: Listener) => {
+    windowListeners.set(type, listener);
+  },
+};
+
+const fire = (
+  where: "document" | "window",
+  type: string,
+  event: FakeEvent = {}
+): void => {
+  const listener = (
+    where === "document" ? documentListeners : windowListeners
+  ).get(type);
+  if (!listener) {
+    throw new Error(`no ${where} listener for ${type}`);
+  }
+  listener(event);
+};
+
+const saved = new Map(
+  ["document", "window", "Node", "Element"].map((name) => [
+    name,
+    Object.getOwnPropertyDescriptor(globalThis, name),
+  ])
+);
+
+let installDropdownDismiss: () => void;
+
+beforeAll(async () => {
+  for (const [name, value] of Object.entries({
+    Element: FakeEl,
+    Node: FakeEl,
+    document: fakeDocument,
+    window: fakeWindow,
+  })) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+  ({ installDropdownDismiss } =
+    await import("../src/components/dropdown-dismiss.ts"));
+  installDropdownDismiss();
+});
+
+afterAll(() => {
+  for (const [name, descriptor] of saved) {
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, name);
+    }
+  }
+});
+
+beforeEach(() => {
+  dropdown.open = true;
+  summary.focused = false;
+});
+
+describe("installDropdownDismiss", () => {
+  it("registers each listener once, even when several components install", () => {
+    installDropdownDismiss();
+    installDropdownDismiss();
+    expect([...documentListeners.keys()].toSorted()).toEqual([
+      "focusout",
+      "keydown",
+      "pointerdown",
+    ]);
+    expect([...windowListeners.keys()]).toEqual(["blur"]);
+  });
+});
+
+describe("pointerdown", () => {
+  it("closes the open dropdown on a press outside it", () => {
+    fire("document", "pointerdown", { target: link });
+    expect(dropdown.open).toBe(false);
+    expect(summary.focused).toBe(false);
+  });
+
+  it("leaves the dropdown open on a press inside it", () => {
+    fire("document", "pointerdown", { target: item });
+    expect(dropdown.open).toBe(true);
+    fire("document", "pointerdown", { target: summary });
+    expect(dropdown.open).toBe(true);
+  });
+
+  it("closes on a press whose target is not a node", () => {
+    fire("document", "pointerdown", { target: null });
+    expect(dropdown.open).toBe(false);
+  });
+
+  it("does nothing when no dropdown is open", () => {
+    dropdown.open = false;
+    fire("document", "pointerdown", { target: link });
+    expect(dropdown.open).toBe(false);
+    expect(collapsible.open).toBe(true);
+  });
+});
+
+describe("keydown", () => {
+  it("ignores keys other than Escape", () => {
+    fire("document", "keydown", { key: "Enter", target: item });
+    expect(dropdown.open).toBe(true);
+  });
+
+  it("ignores an IME composition cancel", () => {
+    fire("document", "keydown", {
+      isComposing: true,
+      key: "Escape",
+      target: item,
+    });
+    expect(dropdown.open).toBe(true);
+  });
+
+  it("leaves a dropdown under a modal dialog alone", () => {
+    fire("document", "keydown", { key: "Escape", target: searchInput });
+    expect(dropdown.open).toBe(true);
+    expect(summary.focused).toBe(false);
+  });
+
+  it("closes and returns focus to the trigger when Escape came from inside", () => {
+    fire("document", "keydown", { key: "Escape", target: item });
+    expect(dropdown.open).toBe(false);
+    expect(summary.focused).toBe(true);
+  });
+
+  it("closes without moving focus when Escape came from elsewhere", () => {
+    fire("document", "keydown", { key: "Escape", target: link });
+    expect(dropdown.open).toBe(false);
+    expect(summary.focused).toBe(false);
+  });
+
+  it("does nothing when no dropdown is open", () => {
+    dropdown.open = false;
+    fire("document", "keydown", { key: "Escape", target: link });
+    expect(summary.focused).toBe(false);
+  });
+});
+
+describe("focusout", () => {
+  it("closes when focus moves to an element outside the dropdown", () => {
+    fire("document", "focusout", { relatedTarget: link, target: item });
+    expect(dropdown.open).toBe(false);
+    expect(summary.focused).toBe(false);
+  });
+
+  it("stays open while focus moves within the dropdown", () => {
+    fire("document", "focusout", { relatedTarget: item, target: summary });
+    expect(dropdown.open).toBe(true);
+  });
+
+  it("stays open when focus goes nowhere focusable", () => {
+    fire("document", "focusout", { relatedTarget: null, target: item });
+    expect(dropdown.open).toBe(true);
+  });
+
+  it("does nothing when no dropdown is open", () => {
+    dropdown.open = false;
+    fire("document", "focusout", { relatedTarget: link, target: item });
+    expect(dropdown.open).toBe(false);
+  });
+});
+
+describe("window blur", () => {
+  it("closes the open dropdown", () => {
+    fire("window", "blur");
+    expect(dropdown.open).toBe(false);
+    expect(summary.focused).toBe(false);
+  });
+
+  it("does nothing when no dropdown is open", () => {
+    dropdown.open = false;
+    fire("window", "blur");
+    expect(collapsible.open).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The page-action dropdowns beneath the table of contents — **Export**, **Open in chat**, and **Connect to MCP** — are native `<details>` elements. A native `<details>` only closes when its own `<summary>` is clicked again, so clicking anywhere else on the page leaves the floating panel hanging over the content.

## Fix

Two listeners in `PageActions.astro`:

- **`pointerdown`** — closes the open dropdown unless the press landed inside it, so clicking an item in the panel still works.
- **`keydown`** — Escape closes the open dropdown and returns focus to its trigger.

Both are registered at module scope and query the DOM live, matching the existing `resize` handler's pattern, so `astro:after-swap` re-inits don't stack duplicate listeners.

## Testing

Added an e2e regression test in `apps/docs/e2e/site.e2e.ts`. Confirmed it fails on the unfixed code (the panel stays open after the outside click) and passes with the fix.

Also drove all three dropdowns manually via Playwright against `blume dev` — each closes on an outside click and on Escape, and stays open when clicking an item inside it.

`bun run check`, `bun run typecheck`, and `bun run test:coverage` all pass. Changeset included (`blume: patch`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Page actions, language selection, and navigation dropdowns now close when clicking outside, pressing Escape, moving keyboard focus away, or leaving the browser window.
  * Pressing Escape returns focus to the menu trigger for improved keyboard navigation.

* **Tests**
  * Added end-to-end and automated coverage for dropdown dismissal and keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->