### PR TITLE
feat: Localize the "Open in chat" prompt

### DIFF
--- a/.changeset/open-in-chat-prompt-i18n.md
+++ b/.changeset/open-in-chat-prompt-i18n.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Localize the "Open in chat" prompt. The prompt handed to the chat provider ("Read `<url>` so I can ask you questions about this page.") was hardcoded in English regardless of the site's locale. It now comes from the UI dictionary as `actions.openInChatPrompt` — with `{url}` replaced by the page's raw-Markdown URL at load time — so localized sites send a localized prompt, every shipped starter pack carries a translation, and `i18n.ui` can override the wording like any other chrome string.

--- a/apps/docs/content/docs/configuration/ai.mdx
+++ b/apps/docs/content/docs/configuration/ai.mdx
@@ -117,6 +117,8 @@ The **Open in chat** action opens the current page in an AI assistant — v0, Ch
 
 Like Copy as Markdown, it needs no setup. The assistant fetches the page over its public URL, so it works as soon as the page is deployed.
 
+The prompt is part of the [UI dictionary](/docs/content/i18n#translated-ui) (`actions.openInChatPrompt`), so localized sites send it in their language, and `i18n.ui` can override the wording — keep the `{url}` placeholder, which is replaced with the page's raw-Markdown URL.
+
 To tailor the action, set `ai.openInChat`. `false` hides it entirely, and an array of provider keys — `"v0"`, `"chatgpt"`, `"claude"`, `"t3"`, `"scira"`, `"cursor"` — shows just those providers, in the order you list them:
 
 ```ts blume.config.ts lineNumbers

--- a/packages/blume/src/components/layout/PageActions.astro
+++ b/packages/blume/src/components/layout/PageActions.astro
@@ -95,6 +95,7 @@ const menuRowClass =
 <div
   class="mt-8 space-y-0.5 border-border border-t pt-4"
   data-blume-page-actions
+  data-i18n-chat-prompt={a.openInChatPrompt}
   data-i18n-copied={a.copied}
   data-i18n-generating={a.generating}
   data-mcp-name={mcpName ?? undefined}
@@ -379,9 +380,14 @@ hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }`;
     const copiedLabel = root.getAttribute("data-i18n-copied") || "Copied!";
     const generatingLabel =
       root.getAttribute("data-i18n-generating") || "Generating…";
+    const promptTemplate =
+      root.getAttribute("data-i18n-chat-prompt") ||
+      "Read {url} so I can ask you questions about this page.";
     const absolute = new URL(md, location.origin).href;
+    // Replacer function, not a string: a URL may contain `$`, which a string
+    // replacement would interpret as a substitution pattern.
     const query = encodeURIComponent(
-      `Read ${absolute} so I can ask you questions about this page.`
+      promptTemplate.replace("{url}", () => absolute)
     );
 
     for (const link of root.querySelectorAll("[data-open-in]")) {

--- a/packages/blume/src/components/layout/PageActions.astro
+++ b/packages/blume/src/components/layout/PageActions.astro
@@ -380,9 +380,9 @@ hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }`;
     const copiedLabel = root.getAttribute("data-i18n-copied") || "Copied!";
     const generatingLabel =
       root.getAttribute("data-i18n-generating") || "Generating…";
-    const promptTemplate =
-      root.getAttribute("data-i18n-chat-prompt") ||
-      "Read {url} so I can ask you questions about this page.";
+    // Always stamped: the frontmatter merges `EN_UI.actions` under any
+    // override, so the English default lives only in core/i18n-ui.ts.
+    const promptTemplate = root.getAttribute("data-i18n-chat-prompt") ?? "";
     const absolute = new URL(md, location.origin).href;
     // Replacer function, not a string: a URL may contain `$`, which a string
     // replacement would interpret as a substitution pattern.

--- a/packages/blume/src/components/layout/PageActions.astro
+++ b/packages/blume/src/components/layout/PageActions.astro
@@ -387,7 +387,7 @@ hr { border: 0; border-top: 1px solid #ddd; margin: 2em 0; }`;
     // Replacer function, not a string: a URL may contain `$`, which a string
     // replacement would interpret as a substitution pattern.
     const query = encodeURIComponent(
-      promptTemplate.replace("{url}", () => absolute)
+      promptTemplate.replaceAll("{url}", () => absolute)
     );
 
     for (const link of root.querySelectorAll("[data-open-in]")) {

--- a/packages/blume/src/core/i18n-ui.ts
+++ b/packages/blume/src/core/i18n-ui.ts
@@ -31,6 +31,11 @@ const uiStringsObject = z.object({
       // `{name}` is replaced with the provider's brand name at render time.
       openIn: z.string().default("Open in {name}"),
       openInChat: z.string().default("Open in chat"),
+      // The prompt handed to the chat provider; `{url}` is replaced with the
+      // page's raw-Markdown URL at load time.
+      openInChatPrompt: z
+        .string()
+        .default("Read {url} so I can ask you questions about this page."),
       scrollToTop: z.string().default("Scroll to top"),
     })
     .prefault({}),

--- a/packages/blume/src/core/ui-packs/ar.ts
+++ b/packages/blume/src/core/ui-packs/ar.ts
@@ -20,6 +20,7 @@ export const ar: UIStringsOverride = {
     generating: "جارٍ الإنشاء…",
     openIn: "فتح في {name}",
     openInChat: "فتح في المحادثة",
+    openInChatPrompt: "اقرأ {url} حتى أتمكن من طرح أسئلة حول هذه الصفحة.",
     scrollToTop: "العودة إلى الأعلى",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/bg.ts
+++ b/packages/blume/src/core/ui-packs/bg.ts
@@ -20,6 +20,8 @@ export const bg: UIStringsOverride = {
     generating: "Генериране…",
     openIn: "Отвори в {name}",
     openInChat: "Отвори в чата",
+    openInChatPrompt:
+      "Прочетете {url}, за да мога да задавам въпроси за тази страница.",
     scrollToTop: "Нагоре",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/bn.ts
+++ b/packages/blume/src/core/ui-packs/bn.ts
@@ -20,6 +20,7 @@ export const bn: UIStringsOverride = {
     generating: "তৈরি হচ্ছে…",
     openIn: "{name}-এ খুলুন",
     openInChat: "চ্যাটে খুলুন",
+    openInChatPrompt: "{url} পড়ুন, যাতে আমি এই পৃষ্ঠা সম্পর্কে প্রশ্ন করতে পারি।",
     scrollToTop: "উপরে যান",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/ca.ts
+++ b/packages/blume/src/core/ui-packs/ca.ts
@@ -20,6 +20,8 @@ export const ca: UIStringsOverride = {
     generating: "S'està generant…",
     openIn: "Obre a {name}",
     openInChat: "Obre al xat",
+    openInChatPrompt:
+      "Llegeix {url} perquè pugui fer-te preguntes sobre aquesta pàgina.",
     scrollToTop: "Torna a dalt",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/cs.ts
+++ b/packages/blume/src/core/ui-packs/cs.ts
@@ -20,6 +20,7 @@ export const cs: UIStringsOverride = {
     generating: "Generování…",
     openIn: "Otevřít v {name}",
     openInChat: "Otevřít v chatu",
+    openInChatPrompt: "Přečtěte si {url}, ať se mohu ptát na tuto stránku.",
     scrollToTop: "Zpět nahoru",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/da.ts
+++ b/packages/blume/src/core/ui-packs/da.ts
@@ -20,6 +20,7 @@ export const da: UIStringsOverride = {
     generating: "Genererer…",
     openIn: "Åbn i {name}",
     openInChat: "Åbn i chat",
+    openInChatPrompt: "Læs {url}, så jeg kan stille spørgsmål om denne side.",
     scrollToTop: "Tilbage til toppen",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/de.ts
+++ b/packages/blume/src/core/ui-packs/de.ts
@@ -20,6 +20,8 @@ export const de: UIStringsOverride = {
     generating: "Wird generiert…",
     openIn: "In {name} öffnen",
     openInChat: "Im Chat öffnen",
+    openInChatPrompt:
+      "Lies {url}, damit ich dir Fragen zu dieser Seite stellen kann.",
     scrollToTop: "Nach oben scrollen",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/el.ts
+++ b/packages/blume/src/core/ui-packs/el.ts
@@ -20,6 +20,8 @@ export const el: UIStringsOverride = {
     generating: "Δημιουργία…",
     openIn: "Άνοιγμα στο {name}",
     openInChat: "Άνοιγμα στη συνομιλία",
+    openInChatPrompt:
+      "Διαβάστε το {url} για να μπορώ να κάνω ερωτήσεις για αυτήν τη σελίδα.",
     scrollToTop: "Επιστροφή στην κορυφή",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/el.ts
+++ b/packages/blume/src/core/ui-packs/el.ts
@@ -21,7 +21,7 @@ export const el: UIStringsOverride = {
     openIn: "Άνοιγμα στο {name}",
     openInChat: "Άνοιγμα στη συνομιλία",
     openInChatPrompt:
-      "Διαβάστε το {url} για να μπορώ να κάνω ερωτήσεις για αυτήν τη σελίδα.",
+      "Διαβάστε το {url} για να μπορώ να κάνω ερωτήσεις για αυτή τη σελίδα.",
     scrollToTop: "Επιστροφή στην κορυφή",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/es.ts
+++ b/packages/blume/src/core/ui-packs/es.ts
@@ -20,6 +20,8 @@ export const es: UIStringsOverride = {
     generating: "Generando…",
     openIn: "Abrir en {name}",
     openInChat: "Abrir en el chat",
+    openInChatPrompt:
+      "Lee {url} para que pueda hacerte preguntas sobre esta página.",
     scrollToTop: "Volver arriba",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/fa.ts
+++ b/packages/blume/src/core/ui-packs/fa.ts
@@ -20,6 +20,7 @@ export const fa: UIStringsOverride = {
     generating: "در حال تولید…",
     openIn: "باز کردن در {name}",
     openInChat: "باز کردن در گفتگو",
+    openInChatPrompt: "{url} را بخوانید تا بتوانم درباره این صفحه سؤال بپرسم.",
     scrollToTop: "بازگشت به بالا",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/fi.ts
+++ b/packages/blume/src/core/ui-packs/fi.ts
@@ -20,6 +20,7 @@ export const fi: UIStringsOverride = {
     generating: "Luodaan…",
     openIn: "Avaa sovelluksessa {name}",
     openInChat: "Avaa keskustelussa",
+    openInChatPrompt: "Lue {url}, jotta voin kysyä kysymyksiä tästä sivusta.",
     scrollToTop: "Takaisin ylös",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/fr.ts
+++ b/packages/blume/src/core/ui-packs/fr.ts
@@ -20,6 +20,8 @@ export const fr: UIStringsOverride = {
     generating: "Génération…",
     openIn: "Ouvrir dans {name}",
     openInChat: "Ouvrir dans le chat",
+    openInChatPrompt:
+      "Lisez {url} pour que je puisse vous poser des questions sur cette page.",
     scrollToTop: "Revenir en haut",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/he.ts
+++ b/packages/blume/src/core/ui-packs/he.ts
@@ -20,7 +20,7 @@ export const he: UIStringsOverride = {
     generating: "מייצר…",
     openIn: "פתח ב-{name}",
     openInChat: "פתח בצ'אט",
-    openInChatPrompt: "קרא את {url} כדי שאוכל לשאול שאלות על הדף הזה.",
+    openInChatPrompt: "קרא את {url} כדי שאוכל לשאול שאלות על העמוד הזה.",
     scrollToTop: "חזרה למעלה",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/he.ts
+++ b/packages/blume/src/core/ui-packs/he.ts
@@ -20,6 +20,7 @@ export const he: UIStringsOverride = {
     generating: "מייצר…",
     openIn: "פתח ב-{name}",
     openInChat: "פתח בצ'אט",
+    openInChatPrompt: "קרא את {url} כדי שאוכל לשאול שאלות על הדף הזה.",
     scrollToTop: "חזרה למעלה",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/hi.ts
+++ b/packages/blume/src/core/ui-packs/hi.ts
@@ -20,6 +20,7 @@ export const hi: UIStringsOverride = {
     generating: "जनरेट हो रहा है…",
     openIn: "{name} में खोलें",
     openInChat: "चैट में खोलें",
+    openInChatPrompt: "{url} पढ़ें ताकि मैं इस पेज के बारे में प्रश्न पूछ सकूँ।",
     scrollToTop: "ऊपर जाएँ",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/hr.ts
+++ b/packages/blume/src/core/ui-packs/hr.ts
@@ -20,6 +20,8 @@ export const hr: UIStringsOverride = {
     generating: "Generiranje…",
     openIn: "Otvori u {name}",
     openInChat: "Otvori u chatu",
+    openInChatPrompt:
+      "Pročitajte {url} da mogu postavljati pitanja o ovoj stranici.",
     scrollToTop: "Natrag na vrh",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/hr.ts
+++ b/packages/blume/src/core/ui-packs/hr.ts
@@ -21,7 +21,7 @@ export const hr: UIStringsOverride = {
     openIn: "Otvori u {name}",
     openInChat: "Otvori u chatu",
     openInChatPrompt:
-      "Pročitajte {url} da mogu postavljati pitanja o ovoj stranici.",
+      "Pročitajte {url} — postavljat ću pitanja o ovoj stranici.",
     scrollToTop: "Natrag na vrh",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/hu.ts
+++ b/packages/blume/src/core/ui-packs/hu.ts
@@ -20,6 +20,8 @@ export const hu: UIStringsOverride = {
     generating: "Generálás…",
     openIn: "Megnyitás itt: {name}",
     openInChat: "Megnyitás a csevegésben",
+    openInChatPrompt:
+      "Olvasd el a következőt: {url}, hogy kérdéseket tehessek fel erről az oldalról.",
     scrollToTop: "Vissza a tetejére",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/id.ts
+++ b/packages/blume/src/core/ui-packs/id.ts
@@ -20,6 +20,8 @@ export const id: UIStringsOverride = {
     generating: "Menghasilkan…",
     openIn: "Buka di {name}",
     openInChat: "Buka di obrolan",
+    openInChatPrompt:
+      "Baca {url} agar saya bisa mengajukan pertanyaan tentang halaman ini.",
     scrollToTop: "Kembali ke atas",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/it.ts
+++ b/packages/blume/src/core/ui-packs/it.ts
@@ -20,6 +20,7 @@ export const it: UIStringsOverride = {
     generating: "Generazione in corso…",
     openIn: "Apri in {name}",
     openInChat: "Apri nella chat",
+    openInChatPrompt: "Leggi {url} così posso farti domande su questa pagina.",
     scrollToTop: "Torna su",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/ja.ts
+++ b/packages/blume/src/core/ui-packs/ja.ts
@@ -20,6 +20,8 @@ export const ja: UIStringsOverride = {
     generating: "生成中…",
     openIn: "{name} で開く",
     openInChat: "チャットで開く",
+    openInChatPrompt:
+      "{url} を読んで、このページについての質問に答えられるようにしてください。",
     scrollToTop: "トップに戻る",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/ko.ts
+++ b/packages/blume/src/core/ui-packs/ko.ts
@@ -20,6 +20,8 @@ export const ko: UIStringsOverride = {
     generating: "생성 중…",
     openIn: "{name}에서 열기",
     openInChat: "채팅에서 열기",
+    openInChatPrompt:
+      "{url}을(를) 읽어 주세요. 이 페이지에 대해 질문하겠습니다.",
     scrollToTop: "맨 위로",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/ko.ts
+++ b/packages/blume/src/core/ui-packs/ko.ts
@@ -21,7 +21,7 @@ export const ko: UIStringsOverride = {
     openIn: "{name}에서 열기",
     openInChat: "채팅에서 열기",
     openInChatPrompt:
-      "{url}을(를) 읽어 주세요. 이 페이지에 대해 질문하겠습니다.",
+      "{url} 페이지를 읽어 주세요. 이 페이지에 대해 질문하겠습니다.",
     scrollToTop: "맨 위로",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/nl.ts
+++ b/packages/blume/src/core/ui-packs/nl.ts
@@ -20,6 +20,8 @@ export const nl: UIStringsOverride = {
     generating: "Genereren…",
     openIn: "Openen in {name}",
     openInChat: "Openen in chat",
+    openInChatPrompt:
+      "Lees {url}, zodat ik je vragen kan stellen over deze pagina.",
     scrollToTop: "Naar boven scrollen",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/no.ts
+++ b/packages/blume/src/core/ui-packs/no.ts
@@ -20,6 +20,8 @@ export const no: UIStringsOverride = {
     generating: "Genererer…",
     openIn: "Åpne i {name}",
     openInChat: "Åpne i chat",
+    openInChatPrompt:
+      "Les {url}, slik at jeg kan stille spørsmål om denne siden.",
     scrollToTop: "Til toppen",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/pl.ts
+++ b/packages/blume/src/core/ui-packs/pl.ts
@@ -20,6 +20,8 @@ export const pl: UIStringsOverride = {
     generating: "Generowanie…",
     openIn: "Otwórz w {name}",
     openInChat: "Otwórz w czacie",
+    openInChatPrompt:
+      "Przeczytaj {url}, aby móc odpowiadać na pytania dotyczące tej strony.",
     scrollToTop: "Wróć na górę",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/pt-br.ts
+++ b/packages/blume/src/core/ui-packs/pt-br.ts
@@ -20,6 +20,8 @@ export const ptBR: UIStringsOverride = {
     generating: "Gerando…",
     openIn: "Abrir em {name}",
     openInChat: "Abrir no chat",
+    openInChatPrompt:
+      "Leia {url} para que eu possa fazer perguntas sobre esta página.",
     scrollToTop: "Voltar ao topo",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/pt.ts
+++ b/packages/blume/src/core/ui-packs/pt.ts
@@ -20,6 +20,8 @@ export const pt: UIStringsOverride = {
     generating: "A gerar…",
     openIn: "Abrir em {name}",
     openInChat: "Abrir no chat",
+    openInChatPrompt:
+      "Leia {url} para que eu possa fazer perguntas sobre esta página.",
     scrollToTop: "Voltar ao topo",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/ro.ts
+++ b/packages/blume/src/core/ui-packs/ro.ts
@@ -20,6 +20,8 @@ export const ro: UIStringsOverride = {
     generating: "Se generează…",
     openIn: "Deschide în {name}",
     openInChat: "Deschide în chat",
+    openInChatPrompt:
+      "Citește {url} ca să îți pot pune întrebări despre această pagină.",
     scrollToTop: "Sus de tot",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/ru.ts
+++ b/packages/blume/src/core/ui-packs/ru.ts
@@ -20,6 +20,8 @@ export const ru: UIStringsOverride = {
     generating: "Генерация…",
     openIn: "Открыть в {name}",
     openInChat: "Открыть в чате",
+    openInChatPrompt:
+      "Прочитайте {url} — я буду задавать вопросы об этой странице.",
     scrollToTop: "Наверх",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/sk.ts
+++ b/packages/blume/src/core/ui-packs/sk.ts
@@ -20,6 +20,7 @@ export const sk: UIStringsOverride = {
     generating: "Generovanie…",
     openIn: "Otvoriť v {name}",
     openInChat: "Otvoriť v chate",
+    openInChatPrompt: "Prečítajte si {url} — budem sa pýtať na túto stránku.",
     scrollToTop: "Späť nahor",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/sr.ts
+++ b/packages/blume/src/core/ui-packs/sr.ts
@@ -20,6 +20,7 @@ export const sr: UIStringsOverride = {
     generating: "Генерисање…",
     openIn: "Отвори у {name}",
     openInChat: "Отвори у ћаскању",
+    openInChatPrompt: "Прочитајте {url} — постављаћу питања о овој страници.",
     scrollToTop: "Назад на врх",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/sv.ts
+++ b/packages/blume/src/core/ui-packs/sv.ts
@@ -20,6 +20,8 @@ export const sv: UIStringsOverride = {
     generating: "Genererar…",
     openIn: "Öppna i {name}",
     openInChat: "Öppna i chatt",
+    openInChatPrompt:
+      "Läs {url} så att jag kan ställa frågor om den här sidan.",
     scrollToTop: "Till toppen",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/th.ts
+++ b/packages/blume/src/core/ui-packs/th.ts
@@ -20,6 +20,7 @@ export const th: UIStringsOverride = {
     generating: "กำลังสร้าง…",
     openIn: "เปิดใน {name}",
     openInChat: "เปิดในแชท",
+    openInChatPrompt: "อ่าน {url} เพื่อให้ฉันถามคำถามเกี่ยวกับหน้านี้ได้",
     scrollToTop: "กลับไปด้านบน",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/tr.ts
+++ b/packages/blume/src/core/ui-packs/tr.ts
@@ -20,6 +20,8 @@ export const tr: UIStringsOverride = {
     generating: "Oluşturuluyor…",
     openIn: "{name} içinde aç",
     openInChat: "Sohbette aç",
+    openInChatPrompt:
+      "Bu sayfa hakkında sorular sorabilmem için {url} adresini okuyun.",
     scrollToTop: "Başa dön",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/uk.ts
+++ b/packages/blume/src/core/ui-packs/uk.ts
@@ -20,6 +20,8 @@ export const uk: UIStringsOverride = {
     generating: "Генерація…",
     openIn: "Відкрити в {name}",
     openInChat: "Відкрити в чаті",
+    openInChatPrompt:
+      "Прочитайте {url} — я ставитиму запитання щодо цієї сторінки.",
     scrollToTop: "Нагору",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/vi.ts
+++ b/packages/blume/src/core/ui-packs/vi.ts
@@ -20,6 +20,7 @@ export const vi: UIStringsOverride = {
     generating: "Đang tạo…",
     openIn: "Mở trong {name}",
     openInChat: "Mở trong trò chuyện",
+    openInChatPrompt: "Hãy đọc {url} để tôi có thể đặt câu hỏi về trang này.",
     scrollToTop: "Lên đầu trang",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/zh-tw.ts
+++ b/packages/blume/src/core/ui-packs/zh-tw.ts
@@ -20,6 +20,7 @@ export const zhTW: UIStringsOverride = {
     generating: "產生中…",
     openIn: "在 {name} 中開啟",
     openInChat: "在聊天中開啟",
+    openInChatPrompt: "請閱讀 {url}，以便我針對此頁面提問。",
     scrollToTop: "回到頂部",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/zh-tw.ts
+++ b/packages/blume/src/core/ui-packs/zh-tw.ts
@@ -20,7 +20,7 @@ export const zhTW: UIStringsOverride = {
     generating: "產生中…",
     openIn: "在 {name} 中開啟",
     openInChat: "在聊天中開啟",
-    openInChatPrompt: "請閱讀 {url}，以便我針對此頁面提問。",
+    openInChatPrompt: "請閱讀 {url} 以便我針對此頁面提問。",
     scrollToTop: "回到頂部",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/zh.ts
+++ b/packages/blume/src/core/ui-packs/zh.ts
@@ -20,6 +20,7 @@ export const zh: UIStringsOverride = {
     generating: "生成中…",
     openIn: "在 {name} 中打开",
     openInChat: "在聊天中打开",
+    openInChatPrompt: "请阅读 {url}，以便我就此页面提问。",
     scrollToTop: "回到顶部",
   },
   ask: {

--- a/packages/blume/src/core/ui-packs/zh.ts
+++ b/packages/blume/src/core/ui-packs/zh.ts
@@ -20,7 +20,7 @@ export const zh: UIStringsOverride = {
     generating: "生成中…",
     openIn: "在 {name} 中打开",
     openInChat: "在聊天中打开",
-    openInChatPrompt: "请阅读 {url}，以便我就此页面提问。",
+    openInChatPrompt: "请阅读 {url} 以便我就此页面提问。",
     scrollToTop: "回到顶部",
   },
   ask: {

--- a/packages/blume/test/i18n.test.ts
+++ b/packages/blume/test/i18n.test.ts
@@ -1049,6 +1049,13 @@ describe("UI dictionaries", () => {
         pack.actions?.openInChatPrompt,
         `pack "${code}" openInChatPrompt misses {url}`
       ).toContain("{url}");
+      // The URL must sit on a token boundary: a particle or full-width comma
+      // glued onto it (`{url}을`, `{url}，`) can be swallowed into the URL by
+      // the chat provider's link detection.
+      expect(
+        pack.actions?.openInChatPrompt,
+        `pack "${code}" openInChatPrompt glues text onto {url}`
+      ).toMatch(/\{url\}(?:$|[\s,.])/u);
     }
   });
 

--- a/packages/blume/test/i18n.test.ts
+++ b/packages/blume/test/i18n.test.ts
@@ -1027,6 +1027,31 @@ describe("UI dictionaries", () => {
     }
   });
 
+  it("localizes the open-in-chat prompt in every shipped pack", () => {
+    // Formerly hardcoded English in PageActions' client script; now
+    // dictionary-driven so localized sites hand the chat a localized prompt.
+    // Parameterized: `{url}` is replaced with the page's raw-Markdown URL at
+    // load time, so every translation must carry the placeholder.
+    expect(EN_UI.actions.openInChatPrompt).toBe(
+      "Read {url} so I can ask you questions about this page."
+    );
+    const ja = resolveUIStrings("ja", { defaultLocale: "en" });
+    expect(ja.actions.openInChatPrompt).toContain("{url}");
+    expect(ja.actions.openInChatPrompt).not.toBe(
+      EN_UI.actions.openInChatPrompt
+    );
+    for (const [code, pack] of Object.entries(UI_PACKS)) {
+      expect(
+        pack.actions?.openInChatPrompt,
+        `pack "${code}" misses actions.openInChatPrompt`
+      ).toBeTruthy();
+      expect(
+        pack.actions?.openInChatPrompt,
+        `pack "${code}" openInChatPrompt misses {url}`
+      ).toContain("{url}");
+    }
+  });
+
   it("applies a shipped pack for a translated locale", () => {
     const dict = resolveUIStrings("fr", { defaultLocale: "en" });
     expect(dict.search.button).toBe("Rechercher");


### PR DESCRIPTION
## Problem

The "Open in chat" action pre-fills the chat provider with `Read <url> so I can ask you questions about this page.` — hardcoded in English in `PageActions.astro`'s client script, regardless of the site's locale. The chrome around it is already dictionary-driven (`actions.openIn`, `actions.openInChat`), so a Japanese site shows 「チャットで開く」 and then hands Claude/ChatGPT an English prompt.

I hit this on the Japanese-only docs site I run on Blume (docs.irbank.net). Today we post-process the built `dist/` to swap the sentence for a Japanese one — which works, but breaks on any upstream wording change and isn't available to `blume dev`.

## Change

The prompt moves into the UI dictionary as `actions.openInChatPrompt`, the same route the other formerly-hardcoded chrome strings took:

- **Schema** (`core/i18n-ui.ts`): the new key defaults to the current English sentence, parameterized with `{url}` — the placeholder convention `actions.openIn` (`{name}`) and `changelog.showReleases` (`{version}`) already use. English behavior is byte-for-byte unchanged.
- **PageActions**: the string reaches the client script via a `data-i18n-chat-prompt` attribute (the `data-i18n-copied` pattern), with the English fallback inline. `{url}` is replaced at load time with the page's raw-Markdown URL — via a replacer function rather than a replacement string, since URLs may legally contain `$`, which string replacement would interpret as a substitution pattern.
- **Packs**: all 36 shipped starter packs carry a translation. Each follows the pack's established register (vous in `fr`, du in `de`, formal in `ru`/`uk`/`sr`, Cyrillic where the pack is Cyrillic). In languages where a first-person "so I can ask" would force a speaker gender (e.g. Polish _żebym mógł/mogła_), the sentence is rephrased to a gender-neutral construction. Happy to adjust any of these — they're starter-pack quality, written by a non-native speaker for most locales.
- **Test**: the UI-dictionary suite gains the existing per-pack pattern — every pack must carry the key, and every translation must keep the `{url}` placeholder.
- **Docs**: a note in `configuration/ai.mdx`'s Open in chat section pointing at the dictionary key and the `{url}` placeholder, linking to the Translated UI section.
- **Changeset**: `patch`.

## Related Issues

No open issue. Closest prior art is #200, which made the provider list configurable and localized the labels around the action — the prompt itself was the piece left hardcoded.

## Verification

- `bun run check`, `bun run typecheck`, and `bun run test:coverage` pass locally (macOS, Bun 1.3.14): 2987 tests, 0 fail, `packages/blume` stays at 100% per-file line and function coverage.
- `test/i18n.test.ts` (55 pass) carries the new per-pack assertions; removing the key from any pack fails it by name.

## Checklist

- [x] I've reviewed my code
- [x] I've written tests
- [x] I've generated a change set file
- [x] I've updated the docs, if necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Localized the “Open in chat” prompt across supported languages.
  - The prompt now automatically includes the page’s raw-Markdown URL.
  - Custom UI translations can override the default wording.

- **Documentation**
  - Documented prompt localization, customization, and `{url}` replacement behavior in the AI configuration guide.

- **Bug Fixes**
  - Removed the previously hardcoded English prompt when opening pages in chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->