### PR TITLE
fix: import rafThrottle in Component script block

### DIFF
--- a/.changeset/component-script-rafthrottle-import.md
+++ b/.changeset/component-script-rafthrottle-import.md
@@ -2,4 +2,4 @@
 "blume": patch
 ---
 
-Fix a `ReferenceError: rafThrottle is not defined` thrown on every docs page: the `<Component>` script block used `rafThrottle` without importing it, so the resize handler that reclamps measured preview-frame heights never registered.
+Fix a `ReferenceError: rafThrottle is not defined` thrown on pages that render `<Component>`: the script block used `rafThrottle` without importing it. Preview panes now cap at the viewport with CSS (`max-height: 100lvh`) instead of a resize listener, so a pane capped by a small window grows back when the window does, mobile toolbar collapse no longer resizes it, and the docs page asks already-loaded frames to re-report their height so a report sent before the listener registered isn't lost.

--- a/.changeset/component-script-rafthrottle-import.md
+++ b/.changeset/component-script-rafthrottle-import.md
@@ -1,0 +1,5 @@
+---
+"blume": patch
+---
+
+Fix a `ReferenceError: rafThrottle is not defined` thrown on every docs page: the `<Component>` script block used `rafThrottle` without importing it, so the resize handler that reclamps measured preview-frame heights never registered.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,7 +67,7 @@ The generated catch-all page imports shipped components from `blume/...`, the ge
 
 - Components are styled with Tailwind v4 utilities (via `@tailwindcss/vite` in the generated runtime) — no hand-written CSS files. Design tokens live as `--blume-*` variables mapped into Tailwind's theme; the typography plugin styles MDX content (`prose`). Users never configure Tailwind themselves.
 - Code style is enforced by [Ultracite](https://github.com/haydenbleasel/ultracite) (oxlint + oxfmt). Use arrow function expressions, sorted object keys, and `u`-flag regular expressions with named groups.
-- `.astro` files are not linted by oxlint (it misparses single-file `.astro` syntax); they are type-checked by `astro check` instead. Astro components use PascalCase.
+- `.astro` files are not linted by oxlint (it misparses single-file `.astro` syntax), and nothing type-checks the package's components yet: `tsgo` never sees `.astro`, and the docs app's `blume check` only covers its own files. Review `<script>` blocks by hand — a bare identifier there ships as a runtime `ReferenceError`. Astro components use PascalCase.
 - Tests run on Bun's `bun:test` runner, so the Vitest lint preset is intentionally not extended.
 - Generated runtime files (`.blume/`) are excluded from linting and formatting.
 

--- a/apps/docs/e2e/a11y.e2e.ts
+++ b/apps/docs/e2e/a11y.e2e.ts
@@ -1,6 +1,7 @@
 import { AxeBuilder } from "@axe-core/playwright";
-import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
+
+import { expect, test } from "./fixtures";
 
 /**
  * Serious/critical structural WCAG 2 A/AA violations on a page. `color-contrast`

--- a/apps/docs/e2e/fixtures.ts
+++ b/apps/docs/e2e/fixtures.ts
@@ -1,0 +1,25 @@
+import { test as base } from "@playwright/test";
+
+/**
+ * Shared Playwright `test` that fails on any uncaught page error. Visiting a
+ * page is not enough: an assertion on server-rendered markup passes even when
+ * a shipped script throws at module load (a `<Component>` script once did on
+ * `/docs/content/components`, and the suite that visited it stayed green).
+ */
+export const test = base.extend({
+  page: async ({ page }, run) => {
+    const errors: Error[] = [];
+    page.on("pageerror", (error) => {
+      errors.push(error);
+    });
+    await run(page);
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        `Uncaught page error(s): ${errors.map((error) => error.message).join("; ")}`
+      );
+    }
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/apps/docs/e2e/site.e2e.ts
+++ b/apps/docs/e2e/site.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 test.describe("navigation", () => {
   test("home renders and links into the docs", async ({ page }) => {
@@ -81,6 +81,28 @@ test.describe("content components", () => {
     await page.goto("/docs/content/components");
     const tabs = page.locator("blume-tabs").first();
     await expect(tabs).toBeAttached();
+  });
+
+  test("example previews size their panes from the frame's report", async ({
+    page,
+  }) => {
+    await page.goto("/docs/content/components");
+    const frame = page.locator("iframe[data-blume-example-frame]").first();
+    // Lazy-loaded: the frame only fetches once it nears the viewport.
+    await frame.scrollIntoViewIfNeeded();
+    // The docs page stamps the frame when its height report arrives, so this
+    // proves the whole loop — frame observer → postMessage → listener —
+    // rather than just the markup.
+    await expect(frame).toHaveAttribute("data-blume-reported-height", /^\d+$/u);
+    const panels = frame
+      .locator("xpath=ancestor::blume-tabs[1]")
+      .locator("[data-blume-tab-panel]");
+    await expect(panels).toHaveCount(2);
+    const heights = await panels.evaluateAll((elements) =>
+      elements.map((element) => element.style.height)
+    );
+    expect(heights[0]).toMatch(/^\d+px$/u);
+    expect(heights[1]).toBe(heights[0]);
   });
 });
 

--- a/apps/docs/e2e/site.e2e.ts
+++ b/apps/docs/e2e/site.e2e.ts
@@ -94,15 +94,25 @@ test.describe("content components", () => {
     // proves the whole loop — frame observer → postMessage → listener —
     // rather than just the markup.
     await expect(frame).toHaveAttribute("data-blume-reported-height", /^\d+$/u);
-    const panels = frame
-      .locator("xpath=ancestor::blume-tabs[1]")
-      .locator("[data-blume-tab-panel]");
-    await expect(panels).toHaveCount(2);
-    const heights = await panels.evaluateAll((elements) =>
-      elements.map((element) => element.style.height)
-    );
-    expect(heights[0]).toMatch(/^\d+px$/u);
-    expect(heights[1]).toBe(heights[0]);
+    // Read the report and the panel heights in one round trip: the frame's
+    // observer can re-report between two separate reads and split them.
+    const { heights, reported } = await frame.evaluate((element) => ({
+      heights: Array.from(
+        element
+          .closest("blume-tabs")
+          ?.querySelectorAll<HTMLElement>("[data-blume-tab-panel]") ?? [],
+        (panel) => panel.style.height
+      ),
+      reported: Number(element.dataset.blumeReportedHeight),
+    }));
+    // The script floors the report at `EXAMPLE_PANE_MIN_PX` (288px, see
+    // `example-pane.ts`) and writes the result to both panels — so the height
+    // must be the clamped report, not merely a pair of equal SSR estimates.
+    const EXAMPLE_PANE_MIN_PX = 288;
+    expect(heights).toEqual([
+      `${Math.max(EXAMPLE_PANE_MIN_PX, reported)}px`,
+      `${Math.max(EXAMPLE_PANE_MIN_PX, reported)}px`,
+    ]);
   });
 });
 

--- a/apps/docs/e2e/visual.e2e.ts
+++ b/apps/docs/e2e/visual.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 /**
  * Visual-regression baselines. Opt-in (they need per-OS PNG baselines committed,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -12,8 +12,10 @@ export default defineConfig({
   extends: [core, react, antiSlop],
   ignorePatterns: [
     ...(core.ignorePatterns ?? []),
-    // Astro components are linted by `astro check`, not oxlint, which misparses
-    // single-file `.astro` syntax (template + frontmatter).
+    // oxlint misparses single-file `.astro` syntax (template + frontmatter).
+    // Nothing else gates the package's components either: `tsgo` never sees
+    // `.astro`, and the docs app's `blume check` only reaches its own files.
+    // Review `<script>` blocks by hand — a bare identifier there ships.
     "**/*.astro",
     // Blume's generated runtime is an implementation detail.
     "**/.blume",

--- a/packages/blume/src/astro/templates.ts
+++ b/packages/blume/src/astro/templates.ts
@@ -2912,7 +2912,9 @@ ${entries}
  * (`blume:example-height` via postMessage) so the docs page can size the
  * preview pane to the content instead of guessing from the source line count.
  * A ResizeObserver keeps the report live, so examples that grow or shrink
- * after load (chat threads, accordions) stay in sync.
+ * after load (chat threads, accordions) stay in sync, and the frame re-reports
+ * on request (`blume:example-height-request`) so a report posted before the
+ * docs page's listener registered isn't lost.
  */
 export const examplesPageTemplate = (): string =>
   `---
@@ -2991,7 +2993,7 @@ const Example = entry.Component;
         const bodyStyle = getComputedStyle(document.body);
         const paddingPx =
           parseFloat(bodyStyle.paddingTop) + parseFloat(bodyStyle.paddingBottom);
-        new ResizeObserver(() => {
+        const report = () => {
           window.parent.postMessage(
             {
               height:
@@ -3000,7 +3002,19 @@ const Example = entry.Component;
             },
             window.location.origin
           );
-        }).observe(wrapper);
+        };
+        new ResizeObserver(report).observe(wrapper);
+        // The parent asks for a fresh report when its listener comes up, in
+        // case the first one above was posted before anyone was listening.
+        window.addEventListener("message", (event) => {
+          if (
+            event.source === window.parent &&
+            event.origin === window.location.origin &&
+            event.data?.type === "blume:example-height-request"
+          ) {
+            report();
+          }
+        });
       })();
     </script>
   </body>

--- a/packages/blume/src/components/content/Component.astro
+++ b/packages/blume/src/components/content/Component.astro
@@ -14,6 +14,7 @@ import { CODE_PADDING_BLOCK_REM } from "../../theme/code-block-padding.ts";
 
 import { highlightCode } from "../../markdown/index.ts";
 import { withBase } from "../islands/base-path.ts";
+import { EXAMPLE_PANE_MIN_PX } from "./example-pane.ts";
 import Tab from "./Tab.astro";
 import Tabs from "./Tabs.astro";
 // Generated per project; resolves to an empty map when there are no examples.
@@ -53,9 +54,9 @@ const codeHtml = entry
 // only the initial SSR/no-JS height: once the frame loads it reports its
 // rendered height (see the script below) and both panes follow it, so
 // previews fit the example — including ones that grow or shrink after load.
-// The measured height is never ceilinged — the code tab scrolls inside
-// whatever height it's given (`pre.blume-source`) — but the estimate is:
-// a long source would otherwise render a thousands-of-pixels placeholder
+// The measured height is never ceilinged by the script — the code tab scrolls
+// inside whatever height it's given (`pre.blume-source`) — but the estimate
+// is: a long source would otherwise render a thousands-of-pixels placeholder
 // whose collapse to the measured height no transition could hide. No-JS
 // readers aren't hurt by the cap, since the source scrolls at any height.
 const LINE_PX = 21;
@@ -65,18 +66,33 @@ const REM_PX = 16;
 // language bar). The tab panel and the pre carry no border of their own.
 const PADDING_PX = 2 * CODE_PADDING_BLOCK_REM * REM_PX;
 const ESTIMATE_MAX_PX = 400;
-// The floor also clamps the measured height client-side; it rides along on the
-// iframe as `data-blume-min-pane` so the script and this estimate can't drift.
-const MIN_PANE_PX = 288;
 const lineCount = entry ? entry.code.replace(/\n+$/u, "").split("\n").length : 0;
 const paneHeight = Math.min(
   ESTIMATE_MAX_PX,
-  Math.max(MIN_PANE_PX, lineCount * LINE_PX + PADDING_PX)
+  Math.max(EXAMPLE_PANE_MIN_PX, lineCount * LINE_PX + PADDING_PX)
 );
 const paneStyle = `height:${paneHeight}px`;
 // Animate the settle from the estimate to the measured height so the lazy
 // frame's load doesn't snap the layout.
-const paneClass = "motion-safe:transition-[height] motion-safe:duration-200";
+//
+// `max-h-lvh` refuses growth beyond the viewport. An example that sizes itself
+// to the frame's viewport (h-screen/100svh) tracks whatever height the script
+// sets, so each report would come back as the pane height plus the frame
+// padding — unbounded growth. Capping at the viewport parks that cycle: once
+// the pane reaches it, the frame's content stops changing size and the
+// observer goes quiet. Genuinely tall examples scroll inside the frame past
+// this point, which a taller-than-screen pane wouldn't have spared them
+// anyway. It's a CSS cap rather than a clamp in the script so it follows the
+// window on its own — a pane capped by a small viewport grows back when the
+// window does, with no resize listener — and it's the *large* viewport unit
+// on purpose: `lvh` holds still while a mobile browser's toolbar collapses
+// and expands during scroll, where `innerHeight` (and `svh`/`dvh`) move by
+// the toolbar's height on every direction change and would animate the pane
+// under the reader's finger. `max-height` isn't transitioned, so the cap
+// applies instantly during a live resize drag instead of retargeting the
+// settle tween every frame.
+const paneClass =
+  "max-h-lvh motion-safe:transition-[height] motion-safe:duration-200";
 ---
 
 {
@@ -92,7 +108,6 @@ const paneClass = "motion-safe:transition-[height] motion-safe:duration-200";
         <iframe
           class="h-full w-full"
           data-blume-example-frame
-          data-blume-min-pane={MIN_PANE_PX}
           loading="lazy"
           src={previewSrc}
           title={`Preview of ${path}`}
@@ -111,77 +126,61 @@ const paneClass = "motion-safe:transition-[height] motion-safe:duration-200";
 }
 
 <script>
-  import { rafThrottle } from "../raf-throttle.ts";
+  import { EXAMPLE_PANE_MIN_PX } from "./example-pane.ts";
 
   // Preview frames measure their rendered example and report the height (see
   // `examplesPageTemplate`). One listener serves every <Component> on the
   // page; the sender is matched to its iframe through `event.source`. The
   // measured height replaces the server's line-count estimate on both tab
   // panels together, preserving the shared-height invariant that keeps
-  // Preview/Code toggles from shifting the layout. The floor comes from the
-  // iframe's `data-blume-min-pane` (written next to the server estimate) so
-  // there is one source of truth for it.
+  // Preview/Code toggles from shifting the layout. The viewport cap is CSS
+  // (`max-h-lvh` on the panels — see the frontmatter), so the script only
+  // applies the floor.
+  const HEIGHT_REPORT = "blume:example-height";
+  const HEIGHT_REQUEST = "blume:example-height-request";
 
-  // Refuse growth beyond the viewport. An example that sizes itself to the
-  // frame's viewport (h-screen/100svh) tracks whatever height this listener
-  // sets, so each report would come back as the pane height plus the frame
-  // padding — unbounded growth. Clamping to the viewport parks that cycle:
-  // once the pane reaches it, the frame's content stops changing size and
-  // the observer goes quiet. Genuinely tall examples scroll inside the
-  // frame past this point, which a taller-than-screen pane wouldn't have
-  // spared them anyway.
-  const applyMeasuredHeight = (frame: HTMLIFrameElement) => {
-    const tabs = frame.closest("blume-tabs");
-    const reported = Number(frame.dataset.blumeReportedHeight);
-    if (!tabs || !Number.isFinite(reported)) {
+  const frames = () =>
+    document.querySelectorAll<HTMLIFrameElement>(
+      "iframe[data-blume-example-frame]"
+    );
+
+  window.addEventListener("message", (event) => {
+    if (
+      event.origin !== window.location.origin ||
+      event.data?.type !== HEIGHT_REPORT ||
+      !Number.isFinite(event.data.height)
+    ) {
       return;
     }
-    const height = `${Math.max(
-      Number(frame.dataset.blumeMinPane) || 0,
-      Math.min(reported, window.innerHeight)
-    )}px`;
+    const frame = Array.from(frames()).find(
+      (candidate) => candidate.contentWindow === event.source
+    );
+    const tabs = frame?.closest("blume-tabs");
+    if (!frame || !tabs) {
+      return;
+    }
+    // Recorded on the frame as a marker that its report arrived (the e2e
+    // suite asserts on it); the panels carry the applied height.
+    frame.dataset.blumeReportedHeight = String(event.data.height);
+    const height = `${Math.max(EXAMPLE_PANE_MIN_PX, event.data.height)}px`;
     for (const panel of tabs.querySelectorAll<HTMLElement>(
       "[data-blume-tab-panel]"
     )) {
       panel.style.height = height;
     }
-  };
-
-  window.addEventListener("message", (event) => {
-    if (
-      event.origin !== window.location.origin ||
-      event.data?.type !== "blume:example-height" ||
-      !Number.isFinite(event.data.height)
-    ) {
-      return;
-    }
-    const frames = document.querySelectorAll<HTMLIFrameElement>(
-      "iframe[data-blume-example-frame]"
-    );
-    const frame = Array.from(frames).find(
-      (candidate) => candidate.contentWindow === event.source
-    );
-    if (!frame) {
-      return;
-    }
-    // Keep the raw report around so the viewport clamp can be recomputed
-    // when the window resizes, not only when the frame next reports.
-    frame.dataset.blumeReportedHeight = String(event.data.height);
-    applyMeasuredHeight(frame);
   });
 
-  // A pane capped by a small viewport would otherwise stay small after the
-  // window grows: the frame's content stopped changing size, so its observer
-  // has nothing new to report. rAF-coalesced so a live resize drag runs the
-  // read-then-write pass once per frame, not once per event.
-  window.addEventListener(
-    "resize",
-    rafThrottle(() => {
-      for (const frame of document.querySelectorAll<HTMLIFrameElement>(
-        "iframe[data-blume-example-frame][data-blume-reported-height]"
-      )) {
-        applyMeasuredHeight(frame);
-      }
-    })
-  );
+  // A frame reports once its observer first fires, and nothing re-sends it.
+  // Whether this module runs before that report depends on how the bundle
+  // ships it (inlined in the document, or as a fetched chunk when it shares
+  // code with another script) and on the client router's swap timing, so
+  // don't rely on winning the race: ask every frame that's already loaded to
+  // report again. A frame still loading ignores the ping (it lands on the
+  // initial blank document) and reports on its own once it renders.
+  for (const frame of frames()) {
+    frame.contentWindow?.postMessage(
+      { type: HEIGHT_REQUEST },
+      window.location.origin
+    );
+  }
 </script>

--- a/packages/blume/src/components/content/Component.astro
+++ b/packages/blume/src/components/content/Component.astro
@@ -111,6 +111,8 @@ const paneClass = "motion-safe:transition-[height] motion-safe:duration-200";
 }
 
 <script>
+  import { rafThrottle } from "../raf-throttle.ts";
+
   // Preview frames measure their rendered example and report the height (see
   // `examplesPageTemplate`). One listener serves every <Component> on the
   // page; the sender is matched to its iframe through `event.source`. The

--- a/packages/blume/src/components/content/example-pane.ts
+++ b/packages/blume/src/components/content/example-pane.ts
@@ -1,0 +1,6 @@
+/**
+ * Floor for a `<Component>` preview pane, in CSS pixels. Shared between the
+ * server-side line-count estimate and the client script that applies the
+ * frame's measured height, so the two can't drift.
+ */
+export const EXAMPLE_PANE_MIN_PX = 288;

--- a/packages/blume/test/templates.test.ts
+++ b/packages/blume/test/templates.test.ts
@@ -345,6 +345,13 @@ describe("examplesPageTemplate", () => {
     expect(out).toContain("<div data-blume-example");
     expect(out).toContain("ResizeObserver");
     expect(out).toContain('type: "blume:example-height"');
+    // The docs page pings loaded frames when its listener registers; the
+    // frame must answer, and only to its own parent on the docs origin.
+    expect(out).toContain(
+      'event.data?.type === "blume:example-height-request"'
+    );
+    expect(out).toContain("event.source === window.parent");
+    expect(out).toContain("event.origin === window.location.origin");
     // The body padding folded into the report is read from the live value,
     // not hardcoded — a root font-size override in the user's examples.css
     // must not skew the report.


### PR DESCRIPTION
## Problem

`packages/blume/src/components/content/Component.astro`'s `<script>` block calls `rafThrottle` in its window `resize` listener, but never imports it. `PageActions.astro` imports it correctly from `../raf-throttle.ts`; `Component.astro` was missed.

Since the script block has no imports, Astro inlines it as-is, and every page that renders a `<Component>` throws on load:

```
ReferenceError: rafThrottle is not defined
```

Because the throw happens while registering the `resize` listener, the reclamp of measured preview-frame heights on window resize never runs — a pane capped by a small viewport stays small after the window grows, which is exactly the case that listener exists to handle (per the comment above it).

Reproduced on `blume@1.5.3` and `1.6.3` (any docs page with an example preview, e.g. on sevenui.dev), and the missing import is still present on `main`.

## Fix

One line: import `rafThrottle` in the script block, mirroring `PageActions.astro`. With the import present the script is bundled as a module and the helper resolves. Verified downstream via `patchedDependencies` on 1.5.3: the console error is gone and the resize handler registers.

A patch changeset for `blume` is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an error that could occur when documentation pages rendered component previews.
  - Improved preview pane sizing across browser window changes and mobile toolbar states.
  - Ensured preview panes can grow correctly after being constrained by a smaller viewport.
  - Improved height synchronization for lazy-loaded and already-loaded example previews.
- **Tests**
  - Added coverage for preview sizing, height reporting, secure height-request handling, and prevention of uncaught page errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->