### PR TITLE
Give a reference row room for what it holds

### DIFF
--- a/.changeset/reference-row-vertical-rhythm.md
+++ b/.changeset/reference-row-vertical-rhythm.md
@@ -1,0 +1,7 @@
+---
+"blume": patch
+---
+
+Give a reference row room for what it holds. The row was scaled for a one-line description — 4px between the property name and its description, 8px before the disclosure, 12px of row padding — but a description is a block, so at 4px it sat closer to the label above it than its own paragraphs sat to each other. That inversion is what made a dense reference page read as a wall rather than as rows, and the disclosure below it touched the next row's divider. Every component that draws a reference row now shares one scale: 8px between a row's own lines, 12px before a disclosure, 16px of row padding. Measured on one operation page, the gap between two properties goes from 25px to 33px.
+
+Table cells gain the same treatment for the same reason. At 0.5rem of block padding against a line-height near 1.7, a cell whose content wrapped put more space between its own two lines than between itself and the next row. The inline padding is unchanged on purpose: widening it comes out of column width in a capped article, and on one corpus it pushed cells that fit on two lines onto three, spending the space it had just bought.

--- a/packages/blume/src/components/openapi/Authorization.astro
+++ b/packages/blume/src/components/openapi/Authorization.astro
@@ -39,7 +39,7 @@ const { security } = Astro.props;
             {alternative.map((resolved) => {
               const carrier = schemeCarrier(resolved);
               return (
-                <div class="border-border border-t py-3 first:border-t-0">
+                <div class="border-border border-t py-4 first:border-t-0">
                   <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                     <code class="font-mono text-foreground text-sm">
                       {carrier?.name ?? resolved.key}
@@ -55,10 +55,10 @@ const { security } = Astro.props;
                     )}
                   </div>
                   {resolved.scheme?.description && (
-                    <Description class="mt-1 text-muted-foreground text-sm" text={resolved.scheme.description} />
+                    <Description class="mt-2 text-muted-foreground text-sm" text={resolved.scheme.description} />
                   )}
                   {resolved.scopes.length > 0 && (
-                    <div class="mt-1 flex flex-wrap items-center gap-1 text-xs">
+                    <div class="mt-2 flex flex-wrap items-center gap-1.5 text-xs">
                       <span class="text-muted-foreground">Scopes:</span>
                       {resolved.scopes.map((scope) => (
                         <code class="rounded bg-muted px-1 py-0.5 text-foreground">

--- a/packages/blume/src/components/openapi/Bindings.astro
+++ b/packages/blume/src/components/openapi/Bindings.astro
@@ -54,13 +54,13 @@ const isSchemaish = (value: unknown): value is SchemaLike => {
       </div>
       {groups.map((group) => (
         <div class="not-prose mb-3 rounded-blume border border-border px-4 last:mb-0">
-          <div class="flex items-baseline gap-2 border-border py-3">
+          <div class="flex items-baseline gap-2 border-border py-4">
             <code class="font-mono font-semibold text-foreground text-sm">
               {group.protocol}
             </code>
           </div>
           {group.rows.map((row) => (
-            <div class="border-border border-t py-3">
+            <div class="border-border border-t py-4">
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                 <code class="font-mono text-foreground text-sm">{row.name}</code>
                 {!isSchemaish(row.value) && (

--- a/packages/blume/src/components/openapi/GraphqlFieldsTable.astro
+++ b/packages/blume/src/components/openapi/GraphqlFieldsTable.astro
@@ -47,7 +47,7 @@ const isRequired = (row: GraphqlFieldRow): boolean =>
           const route = routes.get(row.type.name);
           const args = isOutputField(row) ? row.args : [];
           return (
-            <div class="border-border border-t py-3 first:border-t-0">
+            <div class="border-border border-t py-4 first:border-t-0">
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                 <code class="font-mono text-foreground text-sm">
                   {row.name}
@@ -69,10 +69,10 @@ const isRequired = (row: GraphqlFieldRow): boolean =>
                 )}
               </div>
               {row.description && (
-                <Description class="mt-1 text-muted-foreground text-sm" text={row.description} />
+                <Description class="mt-2 text-muted-foreground text-sm" text={row.description} />
               )}
               {"default" in row && row.default !== undefined && (
-                <div class="mt-1 text-muted-foreground text-xs">
+                <div class="mt-2 text-muted-foreground text-xs">
                   Default:{" "}
                   <code class="rounded bg-muted px-1 py-0.5 text-foreground">
                     {row.default}
@@ -80,7 +80,7 @@ const isRequired = (row: GraphqlFieldRow): boolean =>
                 </div>
               )}
               {row.deprecationReason && (
-                <div class="mt-1 text-muted-foreground text-xs">
+                <div class="mt-2 text-muted-foreground text-xs">
                   Deprecated: <span set:text={row.deprecationReason} />
                 </div>
               )}

--- a/packages/blume/src/components/openapi/GraphqlOperation.astro
+++ b/packages/blume/src/components/openapi/GraphqlOperation.astro
@@ -156,7 +156,7 @@ const returnRoute = field ? routes.get(field.type.name) : undefined;
             </div>
             {document.types[field.type.name]?.description && (
               <Description
-                class="mt-1 text-muted-foreground text-sm"
+                class="mt-2 text-muted-foreground text-sm"
                 text={document.types[field.type.name]?.description}
               />
             )}

--- a/packages/blume/src/components/openapi/GraphqlType.astro
+++ b/packages/blume/src/components/openapi/GraphqlType.astro
@@ -87,7 +87,7 @@ const SECTION_HEADING = "mb-2 font-semibold text-foreground text-sm";
           </div>
           <div class="rounded-blume border border-border px-4">
             {(type.enumValues ?? []).map((value) => (
-              <div class="border-border border-t py-3 first:border-t-0">
+              <div class="border-border border-t py-4 first:border-t-0">
                 <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                   <code class="font-mono text-foreground text-sm">
                     {value.name}
@@ -99,10 +99,10 @@ const SECTION_HEADING = "mb-2 font-semibold text-foreground text-sm";
                   )}
                 </div>
                 {value.description && (
-                  <Description class="mt-1 text-muted-foreground text-sm" text={value.description} />
+                  <Description class="mt-2 text-muted-foreground text-sm" text={value.description} />
                 )}
                 {value.deprecationReason && (
-                  <div class="mt-1 text-muted-foreground text-xs">
+                  <div class="mt-2 text-muted-foreground text-xs">
                     Deprecated: <span set:text={value.deprecationReason} />
                   </div>
                 )}

--- a/packages/blume/src/components/openapi/ParametersTable.astro
+++ b/packages/blume/src/components/openapi/ParametersTable.astro
@@ -55,7 +55,7 @@ const groups = SECTIONS.map((section) => ({
           const limits = constraints(resolved);
           const enumValues = Array.isArray(resolved.enum) ? resolved.enum : null;
           return (
-            <div class="border-border border-t py-3 first:border-t-0">
+            <div class="border-border border-t py-4 first:border-t-0">
               <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                 <code class="font-mono text-foreground text-sm">{param.name}</code>
                 <span class="text-muted-foreground text-xs">{type}</span>
@@ -71,15 +71,15 @@ const groups = SECTIONS.map((section) => ({
                 )}
               </div>
               {param.description && (
-                <Description class="mt-1 text-muted-foreground text-sm" text={param.description} />
+                <Description class="mt-2 text-muted-foreground text-sm" text={param.description} />
               )}
               {limits.length > 0 && (
-                <div class="mt-1 text-muted-foreground text-xs">
+                <div class="mt-2 text-muted-foreground text-xs">
                   {limits.join(" · ")}
                 </div>
               )}
               {enumValues && (
-                <div class="mt-1 flex flex-wrap items-center gap-1 text-xs">
+                <div class="mt-2 flex flex-wrap items-center gap-1.5 text-xs">
                   <span class="text-muted-foreground">Allowed:</span>
                   {enumValues.map((value) => (
                     <code class="rounded bg-muted px-1 py-0.5 text-foreground">

--- a/packages/blume/src/components/openapi/SchemaProperty.astro
+++ b/packages/blume/src/components/openapi/SchemaProperty.astro
@@ -55,7 +55,11 @@ const expandable =
   !circular && (hasObjectShape(resolved) || Boolean(items && hasObjectShape(items)));
 ---
 
-<div class="border-border border-t py-3 first:border-t-0 last:pb-0">
+{/* The row's vertical scale is 8 / 12 / 16px, and every other reference table copies it. A
+    description is a block of Markdown, not a line: at 4px it sat closer to the label above it
+    than its own paragraphs sat to each other, and the disclosure below it touched the next row's
+    divider. Each step separates a bigger unit than the one before. */}
+<div class="border-border border-t py-4 first:border-t-0 last:pb-0">
   <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
     <code class="font-mono text-foreground text-sm">{name}</code>
     <span class="text-muted-foreground text-xs"
@@ -78,17 +82,17 @@ const expandable =
   </div>
   {
     description && (
-      <Description class="mt-1 text-muted-foreground text-sm" text={description} />
+      <Description class="mt-2 text-muted-foreground text-sm" text={description} />
     )
   }
   {
     limits.length > 0 && (
-      <div class="mt-1 text-muted-foreground text-xs">{limits.join(" · ")}</div>
+      <div class="mt-2 text-muted-foreground text-xs">{limits.join(" · ")}</div>
     )
   }
   {
     enumValues && (
-      <div class="mt-1 flex flex-wrap items-center gap-1 text-xs">
+      <div class="mt-2 flex flex-wrap items-center gap-1.5 text-xs">
         <span class="text-muted-foreground">Allowed:</span>
         {enumValues.map((value) => (
           <code class="rounded bg-muted px-1 py-0.5 text-foreground">
@@ -100,12 +104,12 @@ const expandable =
   }
   {
     expandable && (
-      <details class="mt-2" open={expandAll}>
+      <details class="mt-3" open={expandAll}>
         <summary class="cursor-pointer select-none text-accent text-xs hover:underline">
           <span class="[details[open]>summary_&]:hidden">Show properties</span>
           <span class="hidden [details[open]>summary_&]:inline">Hide properties</span>
         </summary>
-        <div class="mt-2 border-border border-l pl-4">
+        <div class="mt-3 border-border border-l pl-4">
           <SchemaTable
             schema={schema}
             schemas={schemas}

--- a/packages/blume/src/theme/entry.ts
+++ b/packages/blume/src/theme/entry.ts
@@ -560,9 +560,16 @@ blume-diff {
 /* Restore inner padding on every cell. Typography zeroes the first/last cell's
    inline padding so a borderless table aligns to the prose margin; inside the
    framed wrapper that leaves edge text touching the border. The :is() selector
-   outweighs Typography's :where()-scoped rules so the outer columns get it too. */
+   outweighs Typography's :where()-scoped rules so the outer columns get it too.
+
+   The block padding is 0.75rem against a table line-height near 1.7: at 0.5rem a
+   cell whose content wrapped put MORE space between its own two lines than
+   between itself and the next row, so a table of wrapping cells read as one
+   block rather than as rows. The inline padding stays where it was, deliberately
+   — widening it comes out of column width in a capped article, and on one corpus
+   that pushed cells fitting on two lines onto three. */
 .blume-table-scroll :is(th, td) {
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem;
 }
 /* Keep column labels on one line so a two-word header does not wrap into a
    ragged stack; the table just scrolls a little wider instead. Body cells keep


### PR DESCRIPTION
> Stacked on #250 — the diff shown here includes that branch. Reviewing this after #250 lands (or merging that first) gives the clean two-file diff.

## The row

A reference row is scaled for a one-line description:

| | before | after |
|---|---|---|
| property name → description | 4px | 8px |
| description → "Show properties" | 8px | 12px |
| between two properties | 25px | 33px |

Once #250 renders a description as the Markdown it is, it is a **block** — and at 4px it sat closer to the label above it than its own paragraphs sat to each other (8px). That inversion is what makes a dense reference page read as a wall rather than as rows. The disclosure below it touched the next row's divider.

The new scale is one step per unit: 8px separates a row's own lines, 12px separates the disclosure, 16px of row padding separates the rows. Applied to every component that draws a reference row — `SchemaProperty`, `ParametersTable`, `Authorization`, `GraphqlFieldsTable`, `GraphqlType`, `GraphqlOperation`, `Bindings` — because they are copies of the same row and half of them fixed reads worse than none.

## The table cell

`.blume-table-scroll :is(th, td)` was `0.5rem 0.75rem`. Against a table line-height near 1.7, a cell whose content wraps put **more space between its own two lines than between itself and the next row** — the same inversion, in the component a reference corpus uses most.

Block padding goes to `0.75rem`. The inline padding stays put deliberately: widening it also reads better in isolation, but it comes out of column width in a capped article, and measured on a 448-page corpus it pushed cells that fit on two lines onto three, spending the space it had just bought.

## How the numbers were taken

`getBoundingClientRect` in a headless Chromium against the built pages of a real 448-page corpus, before and after, at 1440px. Not read off the class names — the first pass at this looked right in the source and measured wrong, because the description's internal paragraph margin was the thing setting the floor.

Also verified downstream on that corpus, carrying this as a patch: `blume audit` 34,124 audits with 0 errors and 0 warnings — worth stating because the audit's 2 MB crawl-limit check is sensitive to markup on exactly these pages — 86 tests green, and `blume check --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKgxJk5u2kcfuzHtG2AVNh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved spacing and readability across reference rows, OpenAPI details, GraphQL documentation, bindings, parameters, and schema properties.
  * Standardized descriptions and supporting content with a consistent vertical rhythm.
  * Increased table cell vertical padding while preserving existing horizontal spacing.
* **Bug Fixes**
  * Improved rendering consistency for formatted descriptions throughout API reference pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->